### PR TITLE
BDT cutfiles for DY sample studies

### DIFF
--- a/config2016/Analysis/postVFP/HTLO-amcatnlo/cutTable_lq_eejj_BDT.txt
+++ b/config2016/Analysis/postVFP/HTLO-amcatnlo/cutTable_lq_eejj_BDT.txt
@@ -22,61 +22,61 @@ eleEta_end2           2.000            2.5              -               -       
 #-----------------------------------------------------------------------------------------------------------------------------
 # BDT
 #-----------------------------------------------------------------------------------------------------------------------------
-BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # Analysis year
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/config2016/Analysis/postVFP/HTLO-amcatnlo/cutTable_lq_eejj_BDT.txt
+++ b/config2016/Analysis/postVFP/HTLO-amcatnlo/cutTable_lq_eejj_BDT.txt
@@ -1,0 +1,328 @@
+#############################     Example of file with list of cuts
+#
+#
+#------------------------ Preliminary cut variables and values (cut level -1) here -----------------------------
+# This first list of variable names and values are used to pass configurable values to the user code associated
+# to a variable name.
+# The user can retrieve the values associated to a variable name via a provided function call
+# [e.g. getPreCutValue1("eleFidRegion") and similarly for value2, value3 and value4 ]
+# The idea is that the user can use these values to define the list of objects (electrons, jets, etc.) used in
+# analysis. No cut is automatically evaluated on these variables and the cut level must be equal to -1.
+# Variable names must be unique.
+#
+#VariableName         value1            value2          value3          value4          level
+#------------         ------------      -------------   ------------    -------------   -----
+produceSkim           1                 -               -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Preselection cuts
+#-----------------------------------------------------------------------------------------------------------------------------
+eleEta_bar            1.4442           -                -               -               -1
+eleEta_end1           1.566            2.0              -               -               -1
+eleEta_end2           2.000            2.5              -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# BDT
+#-----------------------------------------------------------------------------------------------------------------------------
+BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Analysis year
+#-----------------------------------------------------------------------------------------------------------------------------
+AnalysisYear   2016  - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# B-tagging
+# See: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation
+#-----------------------------------------------------------------------------------------------------------------------------
+BTagAlgo       DeepJet  - - - -1
+#BTagWP         Loose    - - - -1
+#BTagCutValue   0.0480   - - - -1
+BTagWP         Medium   - - - -1
+BTagCutValue   0.2489   - - - -1
+#
+#-----------------------------------------------------------------------------------------------------------------------------
+# systematics
+#-----------------------------------------------------------------------------------------------------------------------------
+#         name              source/formula/branch                                       cutVars
+#         ------------      ------------------------------------------------------      --------------------------------------
+#SYST      FivePercentUp     1.05
+SYST      PrefireDown       PrefireWeight_Dn/PrefireWeight
+SYST      PrefireUp         PrefireWeight_Up/PrefireWeight
+SYST      JERDown           regex=".+jerdown.*"                                         sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JERUp             regex=".+jerup.*"                                           sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JESDown           regex=".+jesTotaldown.*"                                    sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JESUp             regex=".+jesTotalup.*"                                      sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+#FIXME: EER/EES effect on MET?
+SYST      EERDown           regex=".+EER_Dn.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EERUp             regex=".+EER_Up.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EESDown           regex=".+EES_Dn.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EESUp             regex=".+EES_Up.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EleRecoSFUp       (Ele1_RecoSF_Up/Ele1_RecoSF)*(Ele2_RecoSF_Up/Ele2_RecoSF)
+SYST      EleRecoSFDown     (Ele1_RecoSF_Dn/Ele1_RecoSF)*(Ele2_RecoSF_Dn/Ele2_RecoSF)
+SYST      EleIDSFUp         ((Ele1_HEEPSF+Ele1_HEEPSF_Err)/Ele1_HEEPSF)*((Ele2_HEEPSF+Ele2_HEEPSF_Err)/Ele2_HEEPSF)
+SYST      EleIDSFDown       ((Ele1_HEEPSF-Ele1_HEEPSF_Err)/Ele1_HEEPSF)*((Ele2_HEEPSF-Ele2_HEEPSF_Err)/Ele2_HEEPSF)
+SYST      EleTrigSFUp       
+SYST      EleTrigSFDown     
+SYST      PileupUp          puWeight_Up/puWeight
+SYST      PileupDown        puWeight_Dn/puWeight
+SYST      LHEPdfWeight      LHEPdfWeight
+SYST      LHEScaleWeight    LHEScaleWeight
+#--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
+# The cut variable names, cut boundaries and histogram binnings are provided here by the user.
+# In the event loop of the analysisClass_template.C, the user have to fill each variable with its value using
+# a provided function call [ e.g. fillVariableWithValue("nEleFinal", number_of_electrons) ]
+# The variable names in the user code has to match the names provided here.
+# Variable names must be unique.
+# The cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )
+# in case only the first range (minValue1, maxValue1) is provided,
+# otherwise the cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )  OR  ( minValue2 < VariableName <= maxValue2 )
+# in case even the second range (minValue2, maxValue2) is provided.
+# The level of the cut (0,1,2 ... n) is provided by the user and can be used in the code to easily determine if
+# groups of same-level cuts have passed or failed.
+#
+#VariableName                   minValue1(<) maxValue1(>=)      minValue2(<)    maxValue2(>=)   level   histoNbinsMinMax      OptionalFlag
+#------------                   ------------ -------------      ------------    -------------   -----   ----------------      ------------
+#-----------------------------------------------------------------------------------------------------------------------------
+#                          _           _   _             
+# _ __  _ __ ___  ___  ___| | ___  ___| |_(_) ___  _ __  
+#| '_ \| '__/ _ \/ __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \ 
+#| |_) | | |  __/\__ \  __/ |  __/ (__| |_| | (_) | | | |
+#| .__/|_|  \___||___/\___|_|\___|\___|\__|_|\___/|_| |_|
+#|_|                    
+#-----------------------------------------------------------------------------------------------------------------------------
+Reweighting                        0              1              -           -           0           2             -0.5           1.5
+PassLHECuts                        0              1              -           -           0           2             -0.5           1.5
+PassJSON                           0              1              -           -           0           2             -0.5           1.5
+PassHLT                            0              1              -           -           0           2             -0.5           1.5
+PassGlobalSuperTightHalo2016Filter 0              1              -           -           0           2             -0.5           1.5
+PassGoodVertices                   0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseFilter                0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseIsoFilter             0              1              -           -           0           2             -0.5           1.5
+PassBadEESupercrystalFilter        0              1              -           -           0           2             -0.5           1.5
+PassEcalDeadCellTrigPrim           0              1              -           -           0           2             -0.5           1.5
+PassBadPFMuonFilter                0              1              -           -           0           2             -0.5           1.5
+PassEcalBadCalibFilter             0              1              -           -           0           2             -0.5           1.5
+PassNEle                           0              1              -           -           0           11            -0.5           10.5
+PassNMuon                          0              1              -           -           0           16            -0.5           15.5
+nEle_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+nJet_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+Ele1_Pt_skim                       40             +inf           -           -           0           200           0              2000
+Ele2_Pt_skim                       40             +inf           -           -           0           200           0              2000
+nJet                               -inf           +inf           -           -           0           16            -0.5           15.5
+Jet1_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet1_Eta                           -2.4           2.4            -           -           0           100           -5             5
+Jet2_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet2_Eta                           -2.4           2.4            -           -           0           100           -5             5
+DR_Ele1Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele1Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Jet1Jet2                        -inf           +inf           -           -           0           100           0              10
+PFMET_Type1_Pt                     -inf           +inf           -           -           0           200           0              20
+PFMET_Type1_Phi                    -inf           +inf           -           -           0           200           0              2000
+Ele1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.14
+Ele2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Ele1_Eta                           -inf           +inf           -           -           0           100           -5             5
+Ele2_Eta                           -inf           +inf           -           -           0           100           -5             5
+M_e1j1                             -inf           +inf           -           -           0           200           0              2000
+M_e1j2                             -inf           +inf           -           -           0           200           0              2000
+M_e2j1                             -inf           +inf           -           -           0           200           0              2000
+M_e2j2                             -inf           +inf           -           -           0           200           0              2000
+Jet3_Pt                            -inf           +inf           -           -           0           200           0              2000
+Jet3_Eta                           -inf           +inf           -           -           0           100           -5             5
+Jet1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet3_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Masym                              -inf           +inf           -           -           0           200           0              2000
+MejMin                             -inf           +inf           -           -           0           200           0              2000
+MejMax                             -inf           +inf           -           -           0           200           0              2000
+Meejj                              -inf           +inf           -           -           0           200           0              2000
+Pt_e1e2_skim                       50             +inf           -           -           0           200           0              2000
+sT_eejj_skim                       200            +inf           -           -           0           200           0              2000
+M_e1e2_skim                        40             +inf           -           -           0           200           0              2000
+skim_selection                     -inf           +inf           -           -           0           2             -0.5           1.5
+Ele1_Pt                            50             +inf           -           -           0           200           0              2000
+Ele2_Pt                            50             +inf           -           -           0           200           0              2000
+Jet1_Pt                            50             +inf           -           -           0           200           0              2000
+Jet2_Pt                            50             +inf           -           -           0           200           0              2000
+Pt_e1e2                            70             +inf           -           -           0           200           0              2000
+sT_eejj_bkgCR                      300            +inf           -           -           0           200           0              2000
+M_e1e2_bkgCR                       50             +inf           -           -           0           200           0              2000
+preselection                       -inf           +inf           -           -           0           2             -0.5           1.5     SYSTS
+sT_eejj                            400            +inf           -           -           0           200           0              2000    SYSTS
+M_e1e2                             220            +inf           -           -           0           200           0              2000    SYSTS
+trainingSelection                  -inf           +inf           -           -           1           2             -0.5           1.5
+#-----------------------------------------------------------------------------------------------------------------------------
+#  __ _             _            _           _   _                                                                        
+# / _(_)_ __   __ _| |  ___  ___| | ___  ___| |_(_) ___  _ __                                                             
+#| |_| | '_ \ / _` | | / __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \                                                            
+#|  _| | | | | (_| | | \__ \  __/ |  __/ (__| |_| | (_) | | | |                                                           
+#|_| |_|_| |_|\__,_|_| |___/\___|_|\___|\___|\__|_|\___/|_| |_|                                                           
+#-----------------------------------------------------------------------------------------------------------------------------
+# CUTS GET PROGRESSIVELY TIGHTER
+##------------------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 3000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ3000                         -0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2900                         -0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2800                         -0.6807                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2600                         -0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         -0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2500                         -0.1602                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2300                         0.3003                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ300                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2400                         0.3604                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2200                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ400                         0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ500                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2000                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ600                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1600                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1500                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection

--- a/config2016/Analysis/postVFP/HTLO-amcatnlo/cutTable_lq_eejj_QCD_doubleFR.txt
+++ b/config2016/Analysis/postVFP/HTLO-amcatnlo/cutTable_lq_eejj_QCD_doubleFR.txt
@@ -28,61 +28,61 @@ PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016    - - - -
 #-----------------------------------------------------------------------------------------------------------------------------
 # BDT
 #-----------------------------------------------------------------------------------------------------------------------------
-BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # Analysis year
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/config2016/Analysis/postVFP/HTLO-amcatnlo/cutTable_lq_eejj_QCD_doubleFR.txt
+++ b/config2016/Analysis/postVFP/HTLO-amcatnlo/cutTable_lq_eejj_QCD_doubleFR.txt
@@ -1,0 +1,313 @@
+#############################     Example of file with list of cuts
+#
+#
+#------------------------ Preliminary cut variables and values (cut level -1) here -----------------------------
+# This first list of variable names and values are used to pass configurable values to the user code associated
+# to a variable name.
+# The user can retrieve the values associated to a variable name via a provided function call
+# [e.g. getPreCutValue1("eleFidRegion") and similarly for value2, value3 and value4 ]
+# The idea is that the user can use these values to define the list of objects (electrons, jets, etc.) used in
+# analysis. No cut is automatically evaluated on these variables and the cut level must be equal to -1.
+# Variable names must be unique.
+#
+#VariableName         value1            value2          value3          value4          level
+#------------         ------------      -------------   ------------    -------------   -----
+produceSkim           1                 -               -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Preselection cuts
+#-----------------------------------------------------------------------------------------------------------------------------
+eleEta_bar            1.4442           -                -               -               -1
+eleEta_end1           1.566            2.0              -               -               -1
+eleEta_end2           2.000            2.5              -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Fake rates
+#-----------------------------------------------------------------------------------------------------------------------------
+QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016postVFP/fr2DpostVFP.root - - - -1
+QCDCalcType            double   -   -   -   -1
+PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016    - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# BDT
+#-----------------------------------------------------------------------------------------------------------------------------
+BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Analysis year
+#-----------------------------------------------------------------------------------------------------------------------------
+AnalysisYear   2016postVFP  - - - -1
+#------------------------------------------------------------------------------------------------------
+# Electron ID
+#------------------------------------------------------------------------------------------------------
+electronIDType             HEEP  - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# B-tagging
+# See: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation
+#-----------------------------------------------------------------------------------------------------------------------------
+BTagAlgo       DeepJet  - - - -1
+#BTagWP         Loose    - - - -1
+#BTagCutValue   0.0480   - - - -1
+BTagWP         Medium   - - - -1
+BTagCutValue   0.2489   - - - -1
+#
+#-----------------------------------------------------------------------------------------------------------------------------
+#--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
+# The cut variable names, cut boundaries and histogram binnings are provided here by the user.
+# In the event loop of the analysisClass_template.C, the user have to fill each variable with its value using
+# a provided function call [ e.g. fillVariableWithValue("nEleFinal", number_of_electrons) ]
+# The variable names in the user code has to match the names provided here.
+# Variable names must be unique.
+# The cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )
+# in case only the first range (minValue1, maxValue1) is provided,
+# otherwise the cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )  OR  ( minValue2 < VariableName <= maxValue2 )
+# in case even the second range (minValue2, maxValue2) is provided.
+# The level of the cut (0,1,2 ... n) is provided by the user and can be used in the code to easily determine if
+# groups of same-level cuts have passed or failed.
+#
+#VariableName                   minValue1(<) maxValue1(>=)      minValue2(<)    maxValue2(>=)   level   histoNbinsMinMax      OptionalFlag
+#------------                   ------------ -------------      ------------    -------------   -----   ----------------      ------------
+#-----------------------------------------------------------------------------------------------------------------------------
+#                          _           _   _             
+# _ __  _ __ ___  ___  ___| | ___  ___| |_(_) ___  _ __  
+#| '_ \| '__/ _ \/ __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \ 
+#| |_) | | |  __/\__ \  __/ |  __/ (__| |_| | (_) | | | |
+#| .__/|_|  \___||___/\___|_|\___|\___|\__|_|\___/|_| |_|
+#|_|                    
+#-----------------------------------------------------------------------------------------------------------------------------
+Reweighting                        0              1              -           -           0           2             -0.5           1.5
+PassLHECuts                        0              1              -           -           0           2             -0.5           1.5
+PassJSON                           0              1              -           -           0           2             -0.5           1.5
+PassHLT                            0              1              -           -           0           2             -0.5           1.5
+PassGlobalSuperTightHalo2016Filter 0              1              -           -           0           2             -0.5           1.5
+PassGoodVertices                   0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseFilter                0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseIsoFilter             0              1              -           -           0           2             -0.5           1.5
+PassBadEESupercrystalFilter        0              1              -           -           0           2             -0.5           1.5
+PassEcalDeadCellTrigPrim           0              1              -           -           0           2             -0.5           1.5
+PassBadPFMuonFilter                0              1              -           -           0           2             -0.5           1.5
+PassEcalBadCalibFilter             0              1              -           -           0           2             -0.5           1.5
+PassNEle                           0              1              -           -           0           11            -0.5           10.5
+PassNMuon                          0              1              -           -           0           16            -0.5           15.5
+nEle_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+nJet_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+Ele1_Pt_skim                       40             +inf           -           -           0           200           0              2000
+Ele2_Pt_skim                       40             +inf           -           -           0           200           0              2000
+PassIDRequirements                 0              1              -           -           0           2             -0.5           1.5
+nJet                               -inf           +inf           -           -           0           16            -0.5           15.5
+Jet1_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet1_Eta                           -2.4           2.4            -           -           0           100           -5             5
+Jet2_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet2_Eta                           -2.4           2.4            -           -           0           100           -5             5
+DR_Ele1Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele1Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Jet1Jet2                        -inf           +inf           -           -           0           100           0              10
+PFMET_Type1_Pt                     -inf           +inf           -           -           0           200           0              20
+PFMET_Type1_Phi                    -inf           +inf           -           -           0           200           0              2000
+Ele1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.14
+Ele2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Ele1_Eta                           -inf           +inf           -           -           0           100           -5             5
+Ele2_Eta                           -inf           +inf           -           -           0           100           -5             5
+M_e1j1                             -inf           +inf           -           -           0           200           0              2000
+M_e1j2                             -inf           +inf           -           -           0           200           0              2000
+M_e2j1                             -inf           +inf           -           -           0           200           0              2000
+M_e2j2                             -inf           +inf           -           -           0           200           0              2000
+Jet3_Pt                            -inf           +inf           -           -           0           200           0              2000
+Jet3_Eta                           -inf           +inf           -           -           0           100           -5             5
+Jet1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet3_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Masym                              -inf           +inf           -           -           0           200           0              2000
+MejMin                             -inf           +inf           -           -           0           200           0              2000
+MejMax                             -inf           +inf           -           -           0           200           0              2000
+Meejj                              -inf           +inf           -           -           0           200           0              2000
+Pt_e1e2_skim                       50             +inf           -           -           0           200           0              2000
+sT_eejj_skim                       200            +inf           -           -           0           200           0              2000
+M_e1e2_skim                        40             +inf           -           -           0           200           0              2000
+skim_selection                     -inf           +inf           -           -           0           2             -0.5           1.5
+Ele1_Pt                            50             +inf           -           -           0           200           0              2000
+Ele2_Pt                            50             +inf           -           -           0           200           0              2000
+Jet1_Pt                            50             +inf           -           -           0           200           0              2000
+Jet2_Pt                            50             +inf           -           -           0           200           0              2000
+Pt_e1e2                            70             +inf           -           -           0           200           0              2000
+sT_eejj_bkgCR                      300            +inf           -           -           0           200           0              2000
+M_e1e2_bkgCR                       50             +inf           -           -           0           200           0              2000
+preselection                       -inf           +inf           -           -           0           2             -0.5           1.5
+sT_eejj                            400            +inf           -           -           0           200           0              2000
+M_e1e2                             220            +inf           -           -           0           200           0              2000
+trainingSelection                  -inf           +inf           -           -           1           2             -0.5           1.5
+#-----------------------------------------------------------------------------------------------------------------------------
+#  __ _             _            _           _   _                                                                        
+# / _(_)_ __   __ _| |  ___  ___| | ___  ___| |_(_) ___  _ __                                                             
+#| |_| | '_ \ / _` | | / __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \                                                            
+#|  _| | | | | (_| | | \__ \  __/ |  __/ (__| |_| | (_) | | | |                                                           
+#|_| |_|_| |_|\__,_|_| |___/\___|_|\___|\___|\__|_|\___/|_| |_|                                                           
+#-----------------------------------------------------------------------------------------------------------------------------
+# CUTS GET PROGRESSIVELY TIGHTER
+##------------------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 3000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ3000                         -0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2900                         -0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2800                         -0.6807                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2600                         -0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         -0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2500                         -0.1602                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2300                         0.3003                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ300                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2400                         0.3604                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2200                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ400                         0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ500                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2000                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ600                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1600                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1500                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection

--- a/config2016/Analysis/postVFP/HTLO-amcatnlo/cutTable_lq_eejj_QCD_singleFR.txt
+++ b/config2016/Analysis/postVFP/HTLO-amcatnlo/cutTable_lq_eejj_QCD_singleFR.txt
@@ -1,0 +1,313 @@
+#############################     Example of file with list of cuts
+#
+#
+#------------------------ Preliminary cut variables and values (cut level -1) here -----------------------------
+# This first list of variable names and values are used to pass configurable values to the user code associated
+# to a variable name.
+# The user can retrieve the values associated to a variable name via a provided function call
+# [e.g. getPreCutValue1("eleFidRegion") and similarly for value2, value3 and value4 ]
+# The idea is that the user can use these values to define the list of objects (electrons, jets, etc.) used in
+# analysis. No cut is automatically evaluated on these variables and the cut level must be equal to -1.
+# Variable names must be unique.
+#
+#VariableName         value1            value2          value3          value4          level
+#------------         ------------      -------------   ------------    -------------   -----
+produceSkim           1                 -               -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Preselection cuts
+#-----------------------------------------------------------------------------------------------------------------------------
+eleEta_bar            1.4442           -                -               -               -1
+eleEta_end1           1.566            2.0              -               -               -1
+eleEta_end2           2.000            2.5              -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Fake rates
+#-----------------------------------------------------------------------------------------------------------------------------
+QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016postVFP/fr2DpostVFP.root - - - -1
+QCDCalcType            single   -   -   -   -1
+PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016 - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# BDT
+#-----------------------------------------------------------------------------------------------------------------------------
+BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/HTLO-amcatnlo/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Analysis year
+#-----------------------------------------------------------------------------------------------------------------------------
+AnalysisYear   2016postVFP  - - - -1
+#------------------------------------------------------------------------------------------------------
+# Electron ID
+#------------------------------------------------------------------------------------------------------
+electronIDType             HEEP  - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# B-tagging
+# See: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation
+#-----------------------------------------------------------------------------------------------------------------------------
+BTagAlgo       DeepJet  - - - -1
+#BTagWP         Loose    - - - -1
+#BTagCutValue   0.0480   - - - -1
+BTagWP         Medium   - - - -1
+BTagCutValue   0.2489   - - - -1
+#
+#-----------------------------------------------------------------------------------------------------------------------------
+#--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
+# The cut variable names, cut boundaries and histogram binnings are provided here by the user.
+# In the event loop of the analysisClass_template.C, the user have to fill each variable with its value using
+# a provided function call [ e.g. fillVariableWithValue("nEleFinal", number_of_electrons) ]
+# The variable names in the user code has to match the names provided here.
+# Variable names must be unique.
+# The cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )
+# in case only the first range (minValue1, maxValue1) is provided,
+# otherwise the cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )  OR  ( minValue2 < VariableName <= maxValue2 )
+# in case even the second range (minValue2, maxValue2) is provided.
+# The level of the cut (0,1,2 ... n) is provided by the user and can be used in the code to easily determine if
+# groups of same-level cuts have passed or failed.
+#
+#VariableName                   minValue1(<) maxValue1(>=)      minValue2(<)    maxValue2(>=)   level   histoNbinsMinMax      OptionalFlag
+#------------                   ------------ -------------      ------------    -------------   -----   ----------------      ------------
+#-----------------------------------------------------------------------------------------------------------------------------
+#                          _           _   _             
+# _ __  _ __ ___  ___  ___| | ___  ___| |_(_) ___  _ __  
+#| '_ \| '__/ _ \/ __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \ 
+#| |_) | | |  __/\__ \  __/ |  __/ (__| |_| | (_) | | | |
+#| .__/|_|  \___||___/\___|_|\___|\___|\__|_|\___/|_| |_|
+#|_|                    
+#-----------------------------------------------------------------------------------------------------------------------------
+Reweighting                        0              1              -           -           0           2             -0.5           1.5
+PassLHECuts                        0              1              -           -           0           2             -0.5           1.5
+PassJSON                           0              1              -           -           0           2             -0.5           1.5
+PassHLT                            0              1              -           -           0           2             -0.5           1.5
+PassGlobalSuperTightHalo2016Filter 0              1              -           -           0           2             -0.5           1.5
+PassGoodVertices                   0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseFilter                0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseIsoFilter             0              1              -           -           0           2             -0.5           1.5
+PassBadEESupercrystalFilter        0              1              -           -           0           2             -0.5           1.5
+PassEcalDeadCellTrigPrim           0              1              -           -           0           2             -0.5           1.5
+PassBadPFMuonFilter                0              1              -           -           0           2             -0.5           1.5
+PassEcalBadCalibFilter             0              1              -           -           0           2             -0.5           1.5
+PassNEle                           0              1              -           -           0           11            -0.5           10.5
+PassNMuon                          0              1              -           -           0           16            -0.5           15.5
+nEle_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+nJet_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+Ele1_Pt_skim                       40             +inf           -           -           0           200           0              2000
+Ele2_Pt_skim                       40             +inf           -           -           0           200           0              2000
+PassIDRequirements                 0              1              -           -           0           2             -0.5           1.5
+nJet                               -inf           +inf           -           -           0           16            -0.5           15.5
+Jet1_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet1_Eta                           -2.4           2.4            -           -           0           100           -5             5
+Jet2_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet2_Eta                           -2.4           2.4            -           -           0           100           -5             5
+DR_Ele1Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele1Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Jet1Jet2                        -inf           +inf           -           -           0           100           0              10
+PFMET_Type1_Pt                     -inf           +inf           -           -           0           200           0              20
+PFMET_Type1_Phi                    -inf           +inf           -           -           0           200           0              2000
+Ele1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.14
+Ele2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Ele1_Eta                           -inf           +inf           -           -           0           100           -5             5
+Ele2_Eta                           -inf           +inf           -           -           0           100           -5             5
+M_e1j1                             -inf           +inf           -           -           0           200           0              2000
+M_e1j2                             -inf           +inf           -           -           0           200           0              2000
+M_e2j1                             -inf           +inf           -           -           0           200           0              2000
+M_e2j2                             -inf           +inf           -           -           0           200           0              2000
+Jet3_Pt                            -inf           +inf           -           -           0           200           0              2000
+Jet3_Eta                           -inf           +inf           -           -           0           100           -5             5
+Jet1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet3_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Masym                              -inf           +inf           -           -           0           200           0              2000
+MejMin                             -inf           +inf           -           -           0           200           0              2000
+MejMax                             -inf           +inf           -           -           0           200           0              2000
+Meejj                              -inf           +inf           -           -           0           200           0              2000
+Pt_e1e2_skim                       50             +inf           -           -           0           200           0              2000
+sT_eejj_skim                       200            +inf           -           -           0           200           0              2000
+M_e1e2_skim                        40             +inf           -           -           0           200           0              2000
+skim_selection                     -inf           +inf           -           -           0           2             -0.5           1.5
+Ele1_Pt                            50             +inf           -           -           0           200           0              2000
+Ele2_Pt                            50             +inf           -           -           0           200           0              2000
+Jet1_Pt                            50             +inf           -           -           0           200           0              2000
+Jet2_Pt                            50             +inf           -           -           0           200           0              2000
+Pt_e1e2                            70             +inf           -           -           0           200           0              2000
+sT_eejj_bkgCR                      300            +inf           -           -           0           200           0              2000
+M_e1e2_bkgCR                       50             +inf           -           -           0           200           0              2000
+preselection                       -inf           +inf           -           -           0           2             -0.5           1.5
+sT_eejj                            400            +inf           -           -           0           200           0              2000
+M_e1e2                             220            +inf           -           -           0           200           0              2000
+trainingSelection                  -inf           +inf           -           -           1           2             -0.5           1.5
+#-----------------------------------------------------------------------------------------------------------------------------
+#  __ _             _            _           _   _                                                                        
+# / _(_)_ __   __ _| |  ___  ___| | ___  ___| |_(_) ___  _ __                                                             
+#| |_| | '_ \ / _` | | / __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \                                                            
+#|  _| | | | | (_| | | \__ \  __/ |  __/ (__| |_| | (_) | | | |                                                           
+#|_| |_|_| |_|\__,_|_| |___/\___|_|\___|\___|\__|_|\___/|_| |_|                                                           
+#-----------------------------------------------------------------------------------------------------------------------------
+# CUTS GET PROGRESSIVELY TIGHTER
+##------------------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 3000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ3000                         -0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2900                         -0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2800                         -0.6807                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2600                         -0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         -0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2500                         -0.1602                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2300                         0.3003                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ300                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2400                         0.3604                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2200                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ400                         0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ500                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2000                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ600                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1600                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1500                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection

--- a/config2016/Analysis/postVFP/ignoreNegWeights/cutTable_lq_eejj_BDT.txt
+++ b/config2016/Analysis/postVFP/ignoreNegWeights/cutTable_lq_eejj_BDT.txt
@@ -1,0 +1,328 @@
+#############################     Example of file with list of cuts
+#
+#
+#------------------------ Preliminary cut variables and values (cut level -1) here -----------------------------
+# This first list of variable names and values are used to pass configurable values to the user code associated
+# to a variable name.
+# The user can retrieve the values associated to a variable name via a provided function call
+# [e.g. getPreCutValue1("eleFidRegion") and similarly for value2, value3 and value4 ]
+# The idea is that the user can use these values to define the list of objects (electrons, jets, etc.) used in
+# analysis. No cut is automatically evaluated on these variables and the cut level must be equal to -1.
+# Variable names must be unique.
+#
+#VariableName         value1            value2          value3          value4          level
+#------------         ------------      -------------   ------------    -------------   -----
+produceSkim           1                 -               -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Preselection cuts
+#-----------------------------------------------------------------------------------------------------------------------------
+eleEta_bar            1.4442           -                -               -               -1
+eleEta_end1           1.566            2.0              -               -               -1
+eleEta_end2           2.000            2.5              -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# BDT
+#-----------------------------------------------------------------------------------------------------------------------------
+BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Analysis year
+#-----------------------------------------------------------------------------------------------------------------------------
+AnalysisYear   2016  - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# B-tagging
+# See: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation
+#-----------------------------------------------------------------------------------------------------------------------------
+BTagAlgo       DeepJet  - - - -1
+#BTagWP         Loose    - - - -1
+#BTagCutValue   0.0480   - - - -1
+BTagWP         Medium   - - - -1
+BTagCutValue   0.2489   - - - -1
+#
+#-----------------------------------------------------------------------------------------------------------------------------
+# systematics
+#-----------------------------------------------------------------------------------------------------------------------------
+#         name              source/formula/branch                                       cutVars
+#         ------------      ------------------------------------------------------      --------------------------------------
+#SYST      FivePercentUp     1.05
+SYST      PrefireDown       PrefireWeight_Dn/PrefireWeight
+SYST      PrefireUp         PrefireWeight_Up/PrefireWeight
+SYST      JERDown           regex=".+jerdown.*"                                         sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JERUp             regex=".+jerup.*"                                           sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JESDown           regex=".+jesTotaldown.*"                                    sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JESUp             regex=".+jesTotalup.*"                                      sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+#FIXME: EER/EES effect on MET?
+SYST      EERDown           regex=".+EER_Dn.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EERUp             regex=".+EER_Up.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EESDown           regex=".+EES_Dn.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EESUp             regex=".+EES_Up.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EleRecoSFUp       (Ele1_RecoSF_Up/Ele1_RecoSF)*(Ele2_RecoSF_Up/Ele2_RecoSF)
+SYST      EleRecoSFDown     (Ele1_RecoSF_Dn/Ele1_RecoSF)*(Ele2_RecoSF_Dn/Ele2_RecoSF)
+SYST      EleIDSFUp         ((Ele1_HEEPSF+Ele1_HEEPSF_Err)/Ele1_HEEPSF)*((Ele2_HEEPSF+Ele2_HEEPSF_Err)/Ele2_HEEPSF)
+SYST      EleIDSFDown       ((Ele1_HEEPSF-Ele1_HEEPSF_Err)/Ele1_HEEPSF)*((Ele2_HEEPSF-Ele2_HEEPSF_Err)/Ele2_HEEPSF)
+SYST      EleTrigSFUp       
+SYST      EleTrigSFDown     
+SYST      PileupUp          puWeight_Up/puWeight
+SYST      PileupDown        puWeight_Dn/puWeight
+SYST      LHEPdfWeight      LHEPdfWeight
+SYST      LHEScaleWeight    LHEScaleWeight
+#--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
+# The cut variable names, cut boundaries and histogram binnings are provided here by the user.
+# In the event loop of the analysisClass_template.C, the user have to fill each variable with its value using
+# a provided function call [ e.g. fillVariableWithValue("nEleFinal", number_of_electrons) ]
+# The variable names in the user code has to match the names provided here.
+# Variable names must be unique.
+# The cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )
+# in case only the first range (minValue1, maxValue1) is provided,
+# otherwise the cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )  OR  ( minValue2 < VariableName <= maxValue2 )
+# in case even the second range (minValue2, maxValue2) is provided.
+# The level of the cut (0,1,2 ... n) is provided by the user and can be used in the code to easily determine if
+# groups of same-level cuts have passed or failed.
+#
+#VariableName                   minValue1(<) maxValue1(>=)      minValue2(<)    maxValue2(>=)   level   histoNbinsMinMax      OptionalFlag
+#------------                   ------------ -------------      ------------    -------------   -----   ----------------      ------------
+#-----------------------------------------------------------------------------------------------------------------------------
+#                          _           _   _             
+# _ __  _ __ ___  ___  ___| | ___  ___| |_(_) ___  _ __  
+#| '_ \| '__/ _ \/ __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \ 
+#| |_) | | |  __/\__ \  __/ |  __/ (__| |_| | (_) | | | |
+#| .__/|_|  \___||___/\___|_|\___|\___|\__|_|\___/|_| |_|
+#|_|                    
+#-----------------------------------------------------------------------------------------------------------------------------
+Reweighting                        0              1              -           -           0           2             -0.5           1.5
+PassLHECuts                        0              1              -           -           0           2             -0.5           1.5
+PassJSON                           0              1              -           -           0           2             -0.5           1.5
+PassHLT                            0              1              -           -           0           2             -0.5           1.5
+PassGlobalSuperTightHalo2016Filter 0              1              -           -           0           2             -0.5           1.5
+PassGoodVertices                   0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseFilter                0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseIsoFilter             0              1              -           -           0           2             -0.5           1.5
+PassBadEESupercrystalFilter        0              1              -           -           0           2             -0.5           1.5
+PassEcalDeadCellTrigPrim           0              1              -           -           0           2             -0.5           1.5
+PassBadPFMuonFilter                0              1              -           -           0           2             -0.5           1.5
+PassEcalBadCalibFilter             0              1              -           -           0           2             -0.5           1.5
+PassNEle                           0              1              -           -           0           11            -0.5           10.5
+PassNMuon                          0              1              -           -           0           16            -0.5           15.5
+nEle_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+nJet_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+Ele1_Pt_skim                       40             +inf           -           -           0           200           0              2000
+Ele2_Pt_skim                       40             +inf           -           -           0           200           0              2000
+nJet                               -inf           +inf           -           -           0           16            -0.5           15.5
+Jet1_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet1_Eta                           -2.4           2.4            -           -           0           100           -5             5
+Jet2_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet2_Eta                           -2.4           2.4            -           -           0           100           -5             5
+DR_Ele1Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele1Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Jet1Jet2                        -inf           +inf           -           -           0           100           0              10
+PFMET_Type1_Pt                     -inf           +inf           -           -           0           200           0              20
+PFMET_Type1_Phi                    -inf           +inf           -           -           0           200           0              2000
+Ele1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.14
+Ele2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Ele1_Eta                           -inf           +inf           -           -           0           100           -5             5
+Ele2_Eta                           -inf           +inf           -           -           0           100           -5             5
+M_e1j1                             -inf           +inf           -           -           0           200           0              2000
+M_e1j2                             -inf           +inf           -           -           0           200           0              2000
+M_e2j1                             -inf           +inf           -           -           0           200           0              2000
+M_e2j2                             -inf           +inf           -           -           0           200           0              2000
+Jet3_Pt                            -inf           +inf           -           -           0           200           0              2000
+Jet3_Eta                           -inf           +inf           -           -           0           100           -5             5
+Jet1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet3_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Masym                              -inf           +inf           -           -           0           200           0              2000
+MejMin                             -inf           +inf           -           -           0           200           0              2000
+MejMax                             -inf           +inf           -           -           0           200           0              2000
+Meejj                              -inf           +inf           -           -           0           200           0              2000
+Pt_e1e2_skim                       50             +inf           -           -           0           200           0              2000
+sT_eejj_skim                       200            +inf           -           -           0           200           0              2000
+M_e1e2_skim                        40             +inf           -           -           0           200           0              2000
+skim_selection                     -inf           +inf           -           -           0           2             -0.5           1.5
+Ele1_Pt                            50             +inf           -           -           0           200           0              2000
+Ele2_Pt                            50             +inf           -           -           0           200           0              2000
+Jet1_Pt                            50             +inf           -           -           0           200           0              2000
+Jet2_Pt                            50             +inf           -           -           0           200           0              2000
+Pt_e1e2                            70             +inf           -           -           0           200           0              2000
+sT_eejj_bkgCR                      300            +inf           -           -           0           200           0              2000
+M_e1e2_bkgCR                       50             +inf           -           -           0           200           0              2000
+preselection                       -inf           +inf           -           -           0           2             -0.5           1.5     SYSTS
+sT_eejj                            400            +inf           -           -           0           200           0              2000    SYSTS
+M_e1e2                             220            +inf           -           -           0           200           0              2000    SYSTS
+trainingSelection                  -inf           +inf           -           -           1           2             -0.5           1.5
+#-----------------------------------------------------------------------------------------------------------------------------
+#  __ _             _            _           _   _                                                                        
+# / _(_)_ __   __ _| |  ___  ___| | ___  ___| |_(_) ___  _ __                                                             
+#| |_| | '_ \ / _` | | / __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \                                                            
+#|  _| | | | | (_| | | \__ \  __/ |  __/ (__| |_| | (_) | | | |                                                           
+#|_| |_|_| |_|\__,_|_| |___/\___|_|\___|\___|\__|_|\___/|_| |_|                                                           
+#-----------------------------------------------------------------------------------------------------------------------------
+# CUTS GET PROGRESSIVELY TIGHTER
+##------------------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 3000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ3000                         -0.8609                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         -0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2900                         -0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2800                         -0.7407                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2600                         -0.5606                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2500                         -0.3604                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2300                         -0.02                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2400                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2200                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ300                         0.3804                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ400                         0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ500                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2000                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.8609                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ600                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1300                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1400                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1500                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1600                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection

--- a/config2016/Analysis/postVFP/ignoreNegWeights/cutTable_lq_eejj_BDT.txt
+++ b/config2016/Analysis/postVFP/ignoreNegWeights/cutTable_lq_eejj_BDT.txt
@@ -22,61 +22,61 @@ eleEta_end2           2.000            2.5              -               -       
 #-----------------------------------------------------------------------------------------------------------------------------
 # BDT
 #-----------------------------------------------------------------------------------------------------------------------------
-BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # Analysis year
 #-----------------------------------------------------------------------------------------------------------------------------
@@ -217,103 +217,95 @@ trainingSelection                  -inf           +inf           -           -  
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 3000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ3000                         -0.8609                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2700 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2700                         -0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+BDTOutput_LQ3000                         -0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2900                         -0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+BDTOutput_LQ2900                         -0.8408                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2800                         -0.7407                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+BDTOutput_LQ2800                         -0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2600                         -0.5606                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+BDTOutput_LQ2600                         -0.5806                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         -0.5606                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2500                         -0.3604                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2300 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2300                         -0.02                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2400 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2400                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+BDTOutput_LQ2500                         -0.04                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2200 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2200                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+BDTOutput_LQ2200                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2400                         0.2402                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ300                         0.3804                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+BDTOutput_LQ300                         0.2803                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2300                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ400                         0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+BDTOutput_LQ400                         0.5005                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ500                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+BDTOutput_LQ500                         0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2100 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2100                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+BDTOutput_LQ2100                         0.8208                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2000                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 1900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1900                         0.8609                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+BDTOutput_LQ2000                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ600                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+BDTOutput_LQ600                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1800 optimization
+# LQ M 1900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1800                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 700 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
+BDTOutput_LQ1900                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+BDTOutput_LQ800                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1300 optimization
+# LQ M 1800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1300                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+BDTOutput_LQ1800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1400 optimization
+# LQ M 700 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1400                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+BDTOutput_LQ700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1500 optimization
+# LQ M 900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1500                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+BDTOutput_LQ900                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1600 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1600                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 1500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1500                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 1700 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1000 optimization
 #------------------------------------------------------------------------------------------------------------------
@@ -326,3 +318,11 @@ BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 
 # LQ M 1200 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection

--- a/config2016/Analysis/postVFP/ignoreNegWeights/cutTable_lq_eejj_QCD_doubleFR.txt
+++ b/config2016/Analysis/postVFP/ignoreNegWeights/cutTable_lq_eejj_QCD_doubleFR.txt
@@ -27,63 +27,61 @@ QCDCalcType            double   -   -   -   -1
 PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016    - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # BDT
+#-----------------------------------------------------------------------------------------------------------------------------BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
-
-BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
-
+BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # Analysis year
 #-----------------------------------------------------------------------------------------------------------------------------
@@ -203,103 +201,95 @@ trainingSelection                  -inf           +inf           -           -  
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 3000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ3000                         -0.8609                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2700 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2700                         -0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+BDTOutput_LQ3000                         -0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2900                         -0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+BDTOutput_LQ2900                         -0.8408                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2800                         -0.7407                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+BDTOutput_LQ2800                         -0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2600                         -0.5606                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+BDTOutput_LQ2600                         -0.5806                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         -0.5606                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2500                         -0.3604                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2300 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2300                         -0.02                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2400 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2400                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+BDTOutput_LQ2500                         -0.04                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2200 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2200                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+BDTOutput_LQ2200                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2400                         0.2402                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ300                         0.3804                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+BDTOutput_LQ300                         0.2803                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2300                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ400                         0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+BDTOutput_LQ400                         0.5005                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ500                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+BDTOutput_LQ500                         0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2100 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2100                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+BDTOutput_LQ2100                         0.8208                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2000                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 1900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1900                         0.8609                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+BDTOutput_LQ2000                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ600                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+BDTOutput_LQ600                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1800 optimization
+# LQ M 1900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1800                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 700 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
+BDTOutput_LQ1900                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+BDTOutput_LQ800                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1300 optimization
+# LQ M 1800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1300                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+BDTOutput_LQ1800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1400 optimization
+# LQ M 700 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1400                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+BDTOutput_LQ700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1500 optimization
+# LQ M 900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1500                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+BDTOutput_LQ900                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1600 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1600                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 1500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1500                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 1700 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1000 optimization
 #------------------------------------------------------------------------------------------------------------------
@@ -312,3 +302,11 @@ BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 
 # LQ M 1200 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection

--- a/config2016/Analysis/postVFP/ignoreNegWeights/cutTable_lq_eejj_QCD_doubleFR.txt
+++ b/config2016/Analysis/postVFP/ignoreNegWeights/cutTable_lq_eejj_QCD_doubleFR.txt
@@ -1,0 +1,314 @@
+#############################     Example of file with list of cuts
+#
+#
+#------------------------ Preliminary cut variables and values (cut level -1) here -----------------------------
+# This first list of variable names and values are used to pass configurable values to the user code associated
+# to a variable name.
+# The user can retrieve the values associated to a variable name via a provided function call
+# [e.g. getPreCutValue1("eleFidRegion") and similarly for value2, value3 and value4 ]
+# The idea is that the user can use these values to define the list of objects (electrons, jets, etc.) used in
+# analysis. No cut is automatically evaluated on these variables and the cut level must be equal to -1.
+# Variable names must be unique.
+#
+#VariableName         value1            value2          value3          value4          level
+#------------         ------------      -------------   ------------    -------------   -----
+produceSkim           1                 -               -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Preselection cuts
+#-----------------------------------------------------------------------------------------------------------------------------
+eleEta_bar            1.4442           -                -               -               -1
+eleEta_end1           1.566            2.0              -               -               -1
+eleEta_end2           2.000            2.5              -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Fake rates
+#-----------------------------------------------------------------------------------------------------------------------------
+QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016postVFP/fr2DpostVFP.root - - - -1
+QCDCalcType            double   -   -   -   -1
+PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016    - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# BDT
+
+BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+#-----------------------------------------------------------------------------------------------------------------------------
+# Analysis year
+#-----------------------------------------------------------------------------------------------------------------------------
+AnalysisYear   2016postVFP  - - - -1
+#------------------------------------------------------------------------------------------------------
+# Electron ID
+#------------------------------------------------------------------------------------------------------
+electronIDType             HEEP  - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# B-tagging
+# See: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation
+#-----------------------------------------------------------------------------------------------------------------------------
+BTagAlgo       DeepJet  - - - -1
+#BTagWP         Loose    - - - -1
+#BTagCutValue   0.0480   - - - -1
+BTagWP         Medium   - - - -1
+BTagCutValue   0.2489   - - - -1
+#
+#-----------------------------------------------------------------------------------------------------------------------------
+#--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
+# The cut variable names, cut boundaries and histogram binnings are provided here by the user.
+# In the event loop of the analysisClass_template.C, the user have to fill each variable with its value using
+# a provided function call [ e.g. fillVariableWithValue("nEleFinal", number_of_electrons) ]
+# The variable names in the user code has to match the names provided here.
+# Variable names must be unique.
+# The cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )
+# in case only the first range (minValue1, maxValue1) is provided,
+# otherwise the cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )  OR  ( minValue2 < VariableName <= maxValue2 )
+# in case even the second range (minValue2, maxValue2) is provided.
+# The level of the cut (0,1,2 ... n) is provided by the user and can be used in the code to easily determine if
+# groups of same-level cuts have passed or failed.
+#
+#VariableName                   minValue1(<) maxValue1(>=)      minValue2(<)    maxValue2(>=)   level   histoNbinsMinMax      OptionalFlag
+#------------                   ------------ -------------      ------------    -------------   -----   ----------------      ------------
+#-----------------------------------------------------------------------------------------------------------------------------
+#                          _           _   _             
+# _ __  _ __ ___  ___  ___| | ___  ___| |_(_) ___  _ __  
+#| '_ \| '__/ _ \/ __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \ 
+#| |_) | | |  __/\__ \  __/ |  __/ (__| |_| | (_) | | | |
+#| .__/|_|  \___||___/\___|_|\___|\___|\__|_|\___/|_| |_|
+#|_|                    
+#-----------------------------------------------------------------------------------------------------------------------------
+Reweighting                        0              1              -           -           0           2             -0.5           1.5
+PassLHECuts                        0              1              -           -           0           2             -0.5           1.5
+PassJSON                           0              1              -           -           0           2             -0.5           1.5
+PassHLT                            0              1              -           -           0           2             -0.5           1.5
+PassGlobalSuperTightHalo2016Filter 0              1              -           -           0           2             -0.5           1.5
+PassGoodVertices                   0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseFilter                0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseIsoFilter             0              1              -           -           0           2             -0.5           1.5
+PassBadEESupercrystalFilter        0              1              -           -           0           2             -0.5           1.5
+PassEcalDeadCellTrigPrim           0              1              -           -           0           2             -0.5           1.5
+PassBadPFMuonFilter                0              1              -           -           0           2             -0.5           1.5
+PassEcalBadCalibFilter             0              1              -           -           0           2             -0.5           1.5
+PassNEle                           0              1              -           -           0           11            -0.5           10.5
+PassNMuon                          0              1              -           -           0           16            -0.5           15.5
+nEle_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+nJet_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+Ele1_Pt_skim                       40             +inf           -           -           0           200           0              2000
+Ele2_Pt_skim                       40             +inf           -           -           0           200           0              2000
+PassIDRequirements                 0              1              -           -           0           2             -0.5           1.5
+nJet                               -inf           +inf           -           -           0           16            -0.5           15.5
+Jet1_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet1_Eta                           -2.4           2.4            -           -           0           100           -5             5
+Jet2_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet2_Eta                           -2.4           2.4            -           -           0           100           -5             5
+DR_Ele1Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele1Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Jet1Jet2                        -inf           +inf           -           -           0           100           0              10
+PFMET_Type1_Pt                     -inf           +inf           -           -           0           200           0              20
+PFMET_Type1_Phi                    -inf           +inf           -           -           0           200           0              2000
+Ele1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.14
+Ele2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Ele1_Eta                           -inf           +inf           -           -           0           100           -5             5
+Ele2_Eta                           -inf           +inf           -           -           0           100           -5             5
+M_e1j1                             -inf           +inf           -           -           0           200           0              2000
+M_e1j2                             -inf           +inf           -           -           0           200           0              2000
+M_e2j1                             -inf           +inf           -           -           0           200           0              2000
+M_e2j2                             -inf           +inf           -           -           0           200           0              2000
+Jet3_Pt                            -inf           +inf           -           -           0           200           0              2000
+Jet3_Eta                           -inf           +inf           -           -           0           100           -5             5
+Jet1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet3_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Masym                              -inf           +inf           -           -           0           200           0              2000
+MejMin                             -inf           +inf           -           -           0           200           0              2000
+MejMax                             -inf           +inf           -           -           0           200           0              2000
+Meejj                              -inf           +inf           -           -           0           200           0              2000
+Pt_e1e2_skim                       50             +inf           -           -           0           200           0              2000
+sT_eejj_skim                       200            +inf           -           -           0           200           0              2000
+M_e1e2_skim                        40             +inf           -           -           0           200           0              2000
+skim_selection                     -inf           +inf           -           -           0           2             -0.5           1.5
+Ele1_Pt                            50             +inf           -           -           0           200           0              2000
+Ele2_Pt                            50             +inf           -           -           0           200           0              2000
+Jet1_Pt                            50             +inf           -           -           0           200           0              2000
+Jet2_Pt                            50             +inf           -           -           0           200           0              2000
+Pt_e1e2                            70             +inf           -           -           0           200           0              2000
+sT_eejj_bkgCR                      300            +inf           -           -           0           200           0              2000
+M_e1e2_bkgCR                       50             +inf           -           -           0           200           0              2000
+preselection                       -inf           +inf           -           -           0           2             -0.5           1.5
+sT_eejj                            400            +inf           -           -           0           200           0              2000
+M_e1e2                             220            +inf           -           -           0           200           0              2000
+trainingSelection                  -inf           +inf           -           -           1           2             -0.5           1.5
+#-----------------------------------------------------------------------------------------------------------------------------
+#  __ _             _            _           _   _                                                                        
+# / _(_)_ __   __ _| |  ___  ___| | ___  ___| |_(_) ___  _ __                                                             
+#| |_| | '_ \ / _` | | / __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \                                                            
+#|  _| | | | | (_| | | \__ \  __/ |  __/ (__| |_| | (_) | | | |                                                           
+#|_| |_|_| |_|\__,_|_| |___/\___|_|\___|\___|\__|_|\___/|_| |_|                                                           
+#-----------------------------------------------------------------------------------------------------------------------------
+# CUTS GET PROGRESSIVELY TIGHTER
+##------------------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 3000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ3000                         -0.8609                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         -0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2900                         -0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2800                         -0.7407                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2600                         -0.5606                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2500                         -0.3604                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2300                         -0.02                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2400                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2200                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ300                         0.3804                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ400                         0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ500                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2000                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.8609                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ600                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1300                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1400                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1500                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1600                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection

--- a/config2016/Analysis/postVFP/ignoreNegWeights/cutTable_lq_eejj_QCD_singleFR.txt
+++ b/config2016/Analysis/postVFP/ignoreNegWeights/cutTable_lq_eejj_QCD_singleFR.txt
@@ -1,0 +1,313 @@
+#############################     Example of file with list of cuts
+#
+#
+#------------------------ Preliminary cut variables and values (cut level -1) here -----------------------------
+# This first list of variable names and values are used to pass configurable values to the user code associated
+# to a variable name.
+# The user can retrieve the values associated to a variable name via a provided function call
+# [e.g. getPreCutValue1("eleFidRegion") and similarly for value2, value3 and value4 ]
+# The idea is that the user can use these values to define the list of objects (electrons, jets, etc.) used in
+# analysis. No cut is automatically evaluated on these variables and the cut level must be equal to -1.
+# Variable names must be unique.
+#
+#VariableName         value1            value2          value3          value4          level
+#------------         ------------      -------------   ------------    -------------   -----
+produceSkim           1                 -               -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Preselection cuts
+#-----------------------------------------------------------------------------------------------------------------------------
+eleEta_bar            1.4442           -                -               -               -1
+eleEta_end1           1.566            2.0              -               -               -1
+eleEta_end2           2.000            2.5              -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Fake rates
+#-----------------------------------------------------------------------------------------------------------------------------
+QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016postVFP/fr2DpostVFP.root - - - -1
+QCDCalcType            single   -   -   -   -1
+PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016 - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# BDT
+#-----------------------------------------------------------------------------------------------------------------------------
+BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Analysis year
+#-----------------------------------------------------------------------------------------------------------------------------
+AnalysisYear   2016postVFP  - - - -1
+#------------------------------------------------------------------------------------------------------
+# Electron ID
+#------------------------------------------------------------------------------------------------------
+electronIDType             HEEP  - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# B-tagging
+# See: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation
+#-----------------------------------------------------------------------------------------------------------------------------
+BTagAlgo       DeepJet  - - - -1
+#BTagWP         Loose    - - - -1
+#BTagCutValue   0.0480   - - - -1
+BTagWP         Medium   - - - -1
+BTagCutValue   0.2489   - - - -1
+#
+#-----------------------------------------------------------------------------------------------------------------------------
+#--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
+# The cut variable names, cut boundaries and histogram binnings are provided here by the user.
+# In the event loop of the analysisClass_template.C, the user have to fill each variable with its value using
+# a provided function call [ e.g. fillVariableWithValue("nEleFinal", number_of_electrons) ]
+# The variable names in the user code has to match the names provided here.
+# Variable names must be unique.
+# The cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )
+# in case only the first range (minValue1, maxValue1) is provided,
+# otherwise the cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )  OR  ( minValue2 < VariableName <= maxValue2 )
+# in case even the second range (minValue2, maxValue2) is provided.
+# The level of the cut (0,1,2 ... n) is provided by the user and can be used in the code to easily determine if
+# groups of same-level cuts have passed or failed.
+#
+#VariableName                   minValue1(<) maxValue1(>=)      minValue2(<)    maxValue2(>=)   level   histoNbinsMinMax      OptionalFlag
+#------------                   ------------ -------------      ------------    -------------   -----   ----------------      ------------
+#-----------------------------------------------------------------------------------------------------------------------------
+#                          _           _   _             
+# _ __  _ __ ___  ___  ___| | ___  ___| |_(_) ___  _ __  
+#| '_ \| '__/ _ \/ __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \ 
+#| |_) | | |  __/\__ \  __/ |  __/ (__| |_| | (_) | | | |
+#| .__/|_|  \___||___/\___|_|\___|\___|\__|_|\___/|_| |_|
+#|_|                    
+#-----------------------------------------------------------------------------------------------------------------------------
+Reweighting                        0              1              -           -           0           2             -0.5           1.5
+PassLHECuts                        0              1              -           -           0           2             -0.5           1.5
+PassJSON                           0              1              -           -           0           2             -0.5           1.5
+PassHLT                            0              1              -           -           0           2             -0.5           1.5
+PassGlobalSuperTightHalo2016Filter 0              1              -           -           0           2             -0.5           1.5
+PassGoodVertices                   0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseFilter                0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseIsoFilter             0              1              -           -           0           2             -0.5           1.5
+PassBadEESupercrystalFilter        0              1              -           -           0           2             -0.5           1.5
+PassEcalDeadCellTrigPrim           0              1              -           -           0           2             -0.5           1.5
+PassBadPFMuonFilter                0              1              -           -           0           2             -0.5           1.5
+PassEcalBadCalibFilter             0              1              -           -           0           2             -0.5           1.5
+PassNEle                           0              1              -           -           0           11            -0.5           10.5
+PassNMuon                          0              1              -           -           0           16            -0.5           15.5
+nEle_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+nJet_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+Ele1_Pt_skim                       40             +inf           -           -           0           200           0              2000
+Ele2_Pt_skim                       40             +inf           -           -           0           200           0              2000
+PassIDRequirements                 0              1              -           -           0           2             -0.5           1.5
+nJet                               -inf           +inf           -           -           0           16            -0.5           15.5
+Jet1_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet1_Eta                           -2.4           2.4            -           -           0           100           -5             5
+Jet2_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet2_Eta                           -2.4           2.4            -           -           0           100           -5             5
+DR_Ele1Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele1Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Jet1Jet2                        -inf           +inf           -           -           0           100           0              10
+PFMET_Type1_Pt                     -inf           +inf           -           -           0           200           0              20
+PFMET_Type1_Phi                    -inf           +inf           -           -           0           200           0              2000
+Ele1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.14
+Ele2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Ele1_Eta                           -inf           +inf           -           -           0           100           -5             5
+Ele2_Eta                           -inf           +inf           -           -           0           100           -5             5
+M_e1j1                             -inf           +inf           -           -           0           200           0              2000
+M_e1j2                             -inf           +inf           -           -           0           200           0              2000
+M_e2j1                             -inf           +inf           -           -           0           200           0              2000
+M_e2j2                             -inf           +inf           -           -           0           200           0              2000
+Jet3_Pt                            -inf           +inf           -           -           0           200           0              2000
+Jet3_Eta                           -inf           +inf           -           -           0           100           -5             5
+Jet1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet3_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Masym                              -inf           +inf           -           -           0           200           0              2000
+MejMin                             -inf           +inf           -           -           0           200           0              2000
+MejMax                             -inf           +inf           -           -           0           200           0              2000
+Meejj                              -inf           +inf           -           -           0           200           0              2000
+Pt_e1e2_skim                       50             +inf           -           -           0           200           0              2000
+sT_eejj_skim                       200            +inf           -           -           0           200           0              2000
+M_e1e2_skim                        40             +inf           -           -           0           200           0              2000
+skim_selection                     -inf           +inf           -           -           0           2             -0.5           1.5
+Ele1_Pt                            50             +inf           -           -           0           200           0              2000
+Ele2_Pt                            50             +inf           -           -           0           200           0              2000
+Jet1_Pt                            50             +inf           -           -           0           200           0              2000
+Jet2_Pt                            50             +inf           -           -           0           200           0              2000
+Pt_e1e2                            70             +inf           -           -           0           200           0              2000
+sT_eejj_bkgCR                      300            +inf           -           -           0           200           0              2000
+M_e1e2_bkgCR                       50             +inf           -           -           0           200           0              2000
+preselection                       -inf           +inf           -           -           0           2             -0.5           1.5
+sT_eejj                            400            +inf           -           -           0           200           0              2000
+M_e1e2                             220            +inf           -           -           0           200           0              2000
+trainingSelection                  -inf           +inf           -           -           1           2             -0.5           1.5
+#-----------------------------------------------------------------------------------------------------------------------------
+#  __ _             _            _           _   _                                                                        
+# / _(_)_ __   __ _| |  ___  ___| | ___  ___| |_(_) ___  _ __                                                             
+#| |_| | '_ \ / _` | | / __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \                                                            
+#|  _| | | | | (_| | | \__ \  __/ |  __/ (__| |_| | (_) | | | |                                                           
+#|_| |_|_| |_|\__,_|_| |___/\___|_|\___|\___|\__|_|\___/|_| |_|                                                           
+#-----------------------------------------------------------------------------------------------------------------------------
+# CUTS GET PROGRESSIVELY TIGHTER
+##------------------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 3000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ3000                         -0.8609                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         -0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2900                         -0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2800                         -0.7407                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2600                         -0.5606                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2500                         -0.3604                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2300                         -0.02                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2400                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2200                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ300                         0.3804                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ400                         0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ500                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2000                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.8609                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ600                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1300                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1400                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1500                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1600                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection

--- a/config2016/Analysis/postVFP/ignoreNegWeights/cutTable_lq_eejj_QCD_singleFR.txt
+++ b/config2016/Analysis/postVFP/ignoreNegWeights/cutTable_lq_eejj_QCD_singleFR.txt
@@ -28,61 +28,61 @@ PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016 - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # BDT
 #-----------------------------------------------------------------------------------------------------------------------------
-BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # Analysis year
 #-----------------------------------------------------------------------------------------------------------------------------
@@ -202,103 +202,95 @@ trainingSelection                  -inf           +inf           -           -  
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 3000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ3000                         -0.8609                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2700 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2700                         -0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+BDTOutput_LQ3000                         -0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2900                         -0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+BDTOutput_LQ2900                         -0.8408                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2800                         -0.7407                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+BDTOutput_LQ2800                         -0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2600                         -0.5606                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+BDTOutput_LQ2600                         -0.5806                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         -0.5606                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2500                         -0.3604                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2300 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2300                         -0.02                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2400 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2400                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+BDTOutput_LQ2500                         -0.04                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2200 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2200                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+BDTOutput_LQ2200                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2400                         0.2402                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ300                         0.3804                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+BDTOutput_LQ300                         0.2803                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2300                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ400                         0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+BDTOutput_LQ400                         0.5005                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ500                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+BDTOutput_LQ500                         0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2100 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2100                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+BDTOutput_LQ2100                         0.8208                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2000                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 1900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1900                         0.8609                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+BDTOutput_LQ2000                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ600                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+BDTOutput_LQ600                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1800 optimization
+# LQ M 1900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1800                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 700 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
+BDTOutput_LQ1900                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+BDTOutput_LQ800                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1300 optimization
+# LQ M 1800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1300                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+BDTOutput_LQ1800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1400 optimization
+# LQ M 700 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1400                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+BDTOutput_LQ700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1500 optimization
+# LQ M 900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1500                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+BDTOutput_LQ900                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1600 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1600                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 1500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1500                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 1700 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1000 optimization
 #------------------------------------------------------------------------------------------------------------------
@@ -311,3 +303,11 @@ BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 
 # LQ M 1200 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection

--- a/config2016/Analysis/postVFP/powheg-amcatnlo/cutTable_lq_eejj_BDT.txt
+++ b/config2016/Analysis/postVFP/powheg-amcatnlo/cutTable_lq_eejj_BDT.txt
@@ -22,61 +22,61 @@ eleEta_end2           2.000            2.5              -               -       
 #-----------------------------------------------------------------------------------------------------------------------------
 # BDT
 #-----------------------------------------------------------------------------------------------------------------------------
-BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # Analysis year
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/config2016/Analysis/postVFP/powheg-amcatnlo/cutTable_lq_eejj_BDT.txt
+++ b/config2016/Analysis/postVFP/powheg-amcatnlo/cutTable_lq_eejj_BDT.txt
@@ -1,0 +1,328 @@
+#############################     Example of file with list of cuts
+#
+#
+#------------------------ Preliminary cut variables and values (cut level -1) here -----------------------------
+# This first list of variable names and values are used to pass configurable values to the user code associated
+# to a variable name.
+# The user can retrieve the values associated to a variable name via a provided function call
+# [e.g. getPreCutValue1("eleFidRegion") and similarly for value2, value3 and value4 ]
+# The idea is that the user can use these values to define the list of objects (electrons, jets, etc.) used in
+# analysis. No cut is automatically evaluated on these variables and the cut level must be equal to -1.
+# Variable names must be unique.
+#
+#VariableName         value1            value2          value3          value4          level
+#------------         ------------      -------------   ------------    -------------   -----
+produceSkim           1                 -               -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Preselection cuts
+#-----------------------------------------------------------------------------------------------------------------------------
+eleEta_bar            1.4442           -                -               -               -1
+eleEta_end1           1.566            2.0              -               -               -1
+eleEta_end2           2.000            2.5              -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# BDT
+#-----------------------------------------------------------------------------------------------------------------------------
+BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Analysis year
+#-----------------------------------------------------------------------------------------------------------------------------
+AnalysisYear   2016  - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# B-tagging
+# See: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation
+#-----------------------------------------------------------------------------------------------------------------------------
+BTagAlgo       DeepJet  - - - -1
+#BTagWP         Loose    - - - -1
+#BTagCutValue   0.0480   - - - -1
+BTagWP         Medium   - - - -1
+BTagCutValue   0.2489   - - - -1
+#
+#-----------------------------------------------------------------------------------------------------------------------------
+# systematics
+#-----------------------------------------------------------------------------------------------------------------------------
+#         name              source/formula/branch                                       cutVars
+#         ------------      ------------------------------------------------------      --------------------------------------
+#SYST      FivePercentUp     1.05
+SYST      PrefireDown       PrefireWeight_Dn/PrefireWeight
+SYST      PrefireUp         PrefireWeight_Up/PrefireWeight
+SYST      JERDown           regex=".+jerdown.*"                                         sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JERUp             regex=".+jerup.*"                                           sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JESDown           regex=".+jesTotaldown.*"                                    sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JESUp             regex=".+jesTotalup.*"                                      sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+#FIXME: EER/EES effect on MET?
+SYST      EERDown           regex=".+EER_Dn.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EERUp             regex=".+EER_Up.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EESDown           regex=".+EES_Dn.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EESUp             regex=".+EES_Up.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EleRecoSFUp       (Ele1_RecoSF_Up/Ele1_RecoSF)*(Ele2_RecoSF_Up/Ele2_RecoSF)
+SYST      EleRecoSFDown     (Ele1_RecoSF_Dn/Ele1_RecoSF)*(Ele2_RecoSF_Dn/Ele2_RecoSF)
+SYST      EleIDSFUp         ((Ele1_HEEPSF+Ele1_HEEPSF_Err)/Ele1_HEEPSF)*((Ele2_HEEPSF+Ele2_HEEPSF_Err)/Ele2_HEEPSF)
+SYST      EleIDSFDown       ((Ele1_HEEPSF-Ele1_HEEPSF_Err)/Ele1_HEEPSF)*((Ele2_HEEPSF-Ele2_HEEPSF_Err)/Ele2_HEEPSF)
+SYST      EleTrigSFUp       
+SYST      EleTrigSFDown     
+SYST      PileupUp          puWeight_Up/puWeight
+SYST      PileupDown        puWeight_Dn/puWeight
+SYST      LHEPdfWeight      LHEPdfWeight
+SYST      LHEScaleWeight    LHEScaleWeight
+#--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
+# The cut variable names, cut boundaries and histogram binnings are provided here by the user.
+# In the event loop of the analysisClass_template.C, the user have to fill each variable with its value using
+# a provided function call [ e.g. fillVariableWithValue("nEleFinal", number_of_electrons) ]
+# The variable names in the user code has to match the names provided here.
+# Variable names must be unique.
+# The cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )
+# in case only the first range (minValue1, maxValue1) is provided,
+# otherwise the cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )  OR  ( minValue2 < VariableName <= maxValue2 )
+# in case even the second range (minValue2, maxValue2) is provided.
+# The level of the cut (0,1,2 ... n) is provided by the user and can be used in the code to easily determine if
+# groups of same-level cuts have passed or failed.
+#
+#VariableName                   minValue1(<) maxValue1(>=)      minValue2(<)    maxValue2(>=)   level   histoNbinsMinMax      OptionalFlag
+#------------                   ------------ -------------      ------------    -------------   -----   ----------------      ------------
+#-----------------------------------------------------------------------------------------------------------------------------
+#                          _           _   _             
+# _ __  _ __ ___  ___  ___| | ___  ___| |_(_) ___  _ __  
+#| '_ \| '__/ _ \/ __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \ 
+#| |_) | | |  __/\__ \  __/ |  __/ (__| |_| | (_) | | | |
+#| .__/|_|  \___||___/\___|_|\___|\___|\__|_|\___/|_| |_|
+#|_|                    
+#-----------------------------------------------------------------------------------------------------------------------------
+Reweighting                        0              1              -           -           0           2             -0.5           1.5
+PassLHECuts                        0              1              -           -           0           2             -0.5           1.5
+PassJSON                           0              1              -           -           0           2             -0.5           1.5
+PassHLT                            0              1              -           -           0           2             -0.5           1.5
+PassGlobalSuperTightHalo2016Filter 0              1              -           -           0           2             -0.5           1.5
+PassGoodVertices                   0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseFilter                0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseIsoFilter             0              1              -           -           0           2             -0.5           1.5
+PassBadEESupercrystalFilter        0              1              -           -           0           2             -0.5           1.5
+PassEcalDeadCellTrigPrim           0              1              -           -           0           2             -0.5           1.5
+PassBadPFMuonFilter                0              1              -           -           0           2             -0.5           1.5
+PassEcalBadCalibFilter             0              1              -           -           0           2             -0.5           1.5
+PassNEle                           0              1              -           -           0           11            -0.5           10.5
+PassNMuon                          0              1              -           -           0           16            -0.5           15.5
+nEle_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+nJet_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+Ele1_Pt_skim                       40             +inf           -           -           0           200           0              2000
+Ele2_Pt_skim                       40             +inf           -           -           0           200           0              2000
+nJet                               -inf           +inf           -           -           0           16            -0.5           15.5
+Jet1_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet1_Eta                           -2.4           2.4            -           -           0           100           -5             5
+Jet2_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet2_Eta                           -2.4           2.4            -           -           0           100           -5             5
+DR_Ele1Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele1Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Jet1Jet2                        -inf           +inf           -           -           0           100           0              10
+PFMET_Type1_Pt                     -inf           +inf           -           -           0           200           0              20
+PFMET_Type1_Phi                    -inf           +inf           -           -           0           200           0              2000
+Ele1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.14
+Ele2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Ele1_Eta                           -inf           +inf           -           -           0           100           -5             5
+Ele2_Eta                           -inf           +inf           -           -           0           100           -5             5
+M_e1j1                             -inf           +inf           -           -           0           200           0              2000
+M_e1j2                             -inf           +inf           -           -           0           200           0              2000
+M_e2j1                             -inf           +inf           -           -           0           200           0              2000
+M_e2j2                             -inf           +inf           -           -           0           200           0              2000
+Jet3_Pt                            -inf           +inf           -           -           0           200           0              2000
+Jet3_Eta                           -inf           +inf           -           -           0           100           -5             5
+Jet1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet3_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Masym                              -inf           +inf           -           -           0           200           0              2000
+MejMin                             -inf           +inf           -           -           0           200           0              2000
+MejMax                             -inf           +inf           -           -           0           200           0              2000
+Meejj                              -inf           +inf           -           -           0           200           0              2000
+Pt_e1e2_skim                       50             +inf           -           -           0           200           0              2000
+sT_eejj_skim                       200            +inf           -           -           0           200           0              2000
+M_e1e2_skim                        40             +inf           -           -           0           200           0              2000
+skim_selection                     -inf           +inf           -           -           0           2             -0.5           1.5
+Ele1_Pt                            50             +inf           -           -           0           200           0              2000
+Ele2_Pt                            50             +inf           -           -           0           200           0              2000
+Jet1_Pt                            50             +inf           -           -           0           200           0              2000
+Jet2_Pt                            50             +inf           -           -           0           200           0              2000
+Pt_e1e2                            70             +inf           -           -           0           200           0              2000
+sT_eejj_bkgCR                      300            +inf           -           -           0           200           0              2000
+M_e1e2_bkgCR                       50             +inf           -           -           0           200           0              2000
+preselection                       -inf           +inf           -           -           0           2             -0.5           1.5     SYSTS
+sT_eejj                            400            +inf           -           -           0           200           0              2000    SYSTS
+M_e1e2                             220            +inf           -           -           0           200           0              2000    SYSTS
+trainingSelection                  -inf           +inf           -           -           1           2             -0.5           1.5
+#-----------------------------------------------------------------------------------------------------------------------------
+#  __ _             _            _           _   _                                                                        
+# / _(_)_ __   __ _| |  ___  ___| | ___  ___| |_(_) ___  _ __                                                             
+#| |_| | '_ \ / _` | | / __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \                                                            
+#|  _| | | | | (_| | | \__ \  __/ |  __/ (__| |_| | (_) | | | |                                                           
+#|_| |_|_| |_|\__,_|_| |___/\___|_|\___|\___|\__|_|\___/|_| |_|                                                           
+#-----------------------------------------------------------------------------------------------------------------------------
+# CUTS GET PROGRESSIVELY TIGHTER
+##------------------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 3000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ3000                         -0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2900                         -0.8408                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2800                         -0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2600                         -0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         -0.04                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2500                         0.3203                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ300                         0.4204                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2400                         0.5405                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ400                         0.6006                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2300                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2200                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ500                         0.8208                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.8408                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2000                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ700                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ600                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1500                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1600                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection

--- a/config2016/Analysis/postVFP/powheg-amcatnlo/cutTable_lq_eejj_QCD_doubleFR.txt
+++ b/config2016/Analysis/postVFP/powheg-amcatnlo/cutTable_lq_eejj_QCD_doubleFR.txt
@@ -28,61 +28,61 @@ PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016    - - - -
 #-----------------------------------------------------------------------------------------------------------------------------
 # BDT
 #-----------------------------------------------------------------------------------------------------------------------------
-BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # Analysis year
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/config2016/Analysis/postVFP/powheg-amcatnlo/cutTable_lq_eejj_QCD_doubleFR.txt
+++ b/config2016/Analysis/postVFP/powheg-amcatnlo/cutTable_lq_eejj_QCD_doubleFR.txt
@@ -1,0 +1,313 @@
+#############################     Example of file with list of cuts
+#
+#
+#------------------------ Preliminary cut variables and values (cut level -1) here -----------------------------
+# This first list of variable names and values are used to pass configurable values to the user code associated
+# to a variable name.
+# The user can retrieve the values associated to a variable name via a provided function call
+# [e.g. getPreCutValue1("eleFidRegion") and similarly for value2, value3 and value4 ]
+# The idea is that the user can use these values to define the list of objects (electrons, jets, etc.) used in
+# analysis. No cut is automatically evaluated on these variables and the cut level must be equal to -1.
+# Variable names must be unique.
+#
+#VariableName         value1            value2          value3          value4          level
+#------------         ------------      -------------   ------------    -------------   -----
+produceSkim           1                 -               -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Preselection cuts
+#-----------------------------------------------------------------------------------------------------------------------------
+eleEta_bar            1.4442           -                -               -               -1
+eleEta_end1           1.566            2.0              -               -               -1
+eleEta_end2           2.000            2.5              -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Fake rates
+#-----------------------------------------------------------------------------------------------------------------------------
+QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016postVFP/fr2DpostVFP.root - - - -1
+QCDCalcType            double   -   -   -   -1
+PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016    - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# BDT
+#-----------------------------------------------------------------------------------------------------------------------------
+BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Analysis year
+#-----------------------------------------------------------------------------------------------------------------------------
+AnalysisYear   2016postVFP  - - - -1
+#------------------------------------------------------------------------------------------------------
+# Electron ID
+#------------------------------------------------------------------------------------------------------
+electronIDType             HEEP  - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# B-tagging
+# See: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation
+#-----------------------------------------------------------------------------------------------------------------------------
+BTagAlgo       DeepJet  - - - -1
+#BTagWP         Loose    - - - -1
+#BTagCutValue   0.0480   - - - -1
+BTagWP         Medium   - - - -1
+BTagCutValue   0.2489   - - - -1
+#
+#-----------------------------------------------------------------------------------------------------------------------------
+#--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
+# The cut variable names, cut boundaries and histogram binnings are provided here by the user.
+# In the event loop of the analysisClass_template.C, the user have to fill each variable with its value using
+# a provided function call [ e.g. fillVariableWithValue("nEleFinal", number_of_electrons) ]
+# The variable names in the user code has to match the names provided here.
+# Variable names must be unique.
+# The cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )
+# in case only the first range (minValue1, maxValue1) is provided,
+# otherwise the cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )  OR  ( minValue2 < VariableName <= maxValue2 )
+# in case even the second range (minValue2, maxValue2) is provided.
+# The level of the cut (0,1,2 ... n) is provided by the user and can be used in the code to easily determine if
+# groups of same-level cuts have passed or failed.
+#
+#VariableName                   minValue1(<) maxValue1(>=)      minValue2(<)    maxValue2(>=)   level   histoNbinsMinMax      OptionalFlag
+#------------                   ------------ -------------      ------------    -------------   -----   ----------------      ------------
+#-----------------------------------------------------------------------------------------------------------------------------
+#                          _           _   _             
+# _ __  _ __ ___  ___  ___| | ___  ___| |_(_) ___  _ __  
+#| '_ \| '__/ _ \/ __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \ 
+#| |_) | | |  __/\__ \  __/ |  __/ (__| |_| | (_) | | | |
+#| .__/|_|  \___||___/\___|_|\___|\___|\__|_|\___/|_| |_|
+#|_|                    
+#-----------------------------------------------------------------------------------------------------------------------------
+Reweighting                        0              1              -           -           0           2             -0.5           1.5
+PassLHECuts                        0              1              -           -           0           2             -0.5           1.5
+PassJSON                           0              1              -           -           0           2             -0.5           1.5
+PassHLT                            0              1              -           -           0           2             -0.5           1.5
+PassGlobalSuperTightHalo2016Filter 0              1              -           -           0           2             -0.5           1.5
+PassGoodVertices                   0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseFilter                0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseIsoFilter             0              1              -           -           0           2             -0.5           1.5
+PassBadEESupercrystalFilter        0              1              -           -           0           2             -0.5           1.5
+PassEcalDeadCellTrigPrim           0              1              -           -           0           2             -0.5           1.5
+PassBadPFMuonFilter                0              1              -           -           0           2             -0.5           1.5
+PassEcalBadCalibFilter             0              1              -           -           0           2             -0.5           1.5
+PassNEle                           0              1              -           -           0           11            -0.5           10.5
+PassNMuon                          0              1              -           -           0           16            -0.5           15.5
+nEle_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+nJet_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+Ele1_Pt_skim                       40             +inf           -           -           0           200           0              2000
+Ele2_Pt_skim                       40             +inf           -           -           0           200           0              2000
+PassIDRequirements                 0              1              -           -           0           2             -0.5           1.5
+nJet                               -inf           +inf           -           -           0           16            -0.5           15.5
+Jet1_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet1_Eta                           -2.4           2.4            -           -           0           100           -5             5
+Jet2_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet2_Eta                           -2.4           2.4            -           -           0           100           -5             5
+DR_Ele1Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele1Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Jet1Jet2                        -inf           +inf           -           -           0           100           0              10
+PFMET_Type1_Pt                     -inf           +inf           -           -           0           200           0              20
+PFMET_Type1_Phi                    -inf           +inf           -           -           0           200           0              2000
+Ele1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.14
+Ele2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Ele1_Eta                           -inf           +inf           -           -           0           100           -5             5
+Ele2_Eta                           -inf           +inf           -           -           0           100           -5             5
+M_e1j1                             -inf           +inf           -           -           0           200           0              2000
+M_e1j2                             -inf           +inf           -           -           0           200           0              2000
+M_e2j1                             -inf           +inf           -           -           0           200           0              2000
+M_e2j2                             -inf           +inf           -           -           0           200           0              2000
+Jet3_Pt                            -inf           +inf           -           -           0           200           0              2000
+Jet3_Eta                           -inf           +inf           -           -           0           100           -5             5
+Jet1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet3_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Masym                              -inf           +inf           -           -           0           200           0              2000
+MejMin                             -inf           +inf           -           -           0           200           0              2000
+MejMax                             -inf           +inf           -           -           0           200           0              2000
+Meejj                              -inf           +inf           -           -           0           200           0              2000
+Pt_e1e2_skim                       50             +inf           -           -           0           200           0              2000
+sT_eejj_skim                       200            +inf           -           -           0           200           0              2000
+M_e1e2_skim                        40             +inf           -           -           0           200           0              2000
+skim_selection                     -inf           +inf           -           -           0           2             -0.5           1.5
+Ele1_Pt                            50             +inf           -           -           0           200           0              2000
+Ele2_Pt                            50             +inf           -           -           0           200           0              2000
+Jet1_Pt                            50             +inf           -           -           0           200           0              2000
+Jet2_Pt                            50             +inf           -           -           0           200           0              2000
+Pt_e1e2                            70             +inf           -           -           0           200           0              2000
+sT_eejj_bkgCR                      300            +inf           -           -           0           200           0              2000
+M_e1e2_bkgCR                       50             +inf           -           -           0           200           0              2000
+preselection                       -inf           +inf           -           -           0           2             -0.5           1.5
+sT_eejj                            400            +inf           -           -           0           200           0              2000
+M_e1e2                             220            +inf           -           -           0           200           0              2000
+trainingSelection                  -inf           +inf           -           -           1           2             -0.5           1.5
+#-----------------------------------------------------------------------------------------------------------------------------
+#  __ _             _            _           _   _                                                                        
+# / _(_)_ __   __ _| |  ___  ___| | ___  ___| |_(_) ___  _ __                                                             
+#| |_| | '_ \ / _` | | / __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \                                                            
+#|  _| | | | | (_| | | \__ \  __/ |  __/ (__| |_| | (_) | | | |                                                           
+#|_| |_|_| |_|\__,_|_| |___/\___|_|\___|\___|\__|_|\___/|_| |_|                                                           
+#-----------------------------------------------------------------------------------------------------------------------------
+# CUTS GET PROGRESSIVELY TIGHTER
+##------------------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 3000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ3000                         -0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2900                         -0.8408                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2800                         -0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2600                         -0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         -0.04                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2500                         0.3203                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ300                         0.4204                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2400                         0.5405                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ400                         0.6006                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2300                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2200                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ500                         0.8208                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.8408                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2000                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ700                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ600                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1500                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1600                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection

--- a/config2016/Analysis/postVFP/powheg-amcatnlo/cutTable_lq_eejj_QCD_singleFR.txt
+++ b/config2016/Analysis/postVFP/powheg-amcatnlo/cutTable_lq_eejj_QCD_singleFR.txt
@@ -1,0 +1,313 @@
+#############################     Example of file with list of cuts
+#
+#
+#------------------------ Preliminary cut variables and values (cut level -1) here -----------------------------
+# This first list of variable names and values are used to pass configurable values to the user code associated
+# to a variable name.
+# The user can retrieve the values associated to a variable name via a provided function call
+# [e.g. getPreCutValue1("eleFidRegion") and similarly for value2, value3 and value4 ]
+# The idea is that the user can use these values to define the list of objects (electrons, jets, etc.) used in
+# analysis. No cut is automatically evaluated on these variables and the cut level must be equal to -1.
+# Variable names must be unique.
+#
+#VariableName         value1            value2          value3          value4          level
+#------------         ------------      -------------   ------------    -------------   -----
+produceSkim           1                 -               -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Preselection cuts
+#-----------------------------------------------------------------------------------------------------------------------------
+eleEta_bar            1.4442           -                -               -               -1
+eleEta_end1           1.566            2.0              -               -               -1
+eleEta_end2           2.000            2.5              -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Fake rates
+#-----------------------------------------------------------------------------------------------------------------------------
+QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016postVFP/fr2DpostVFP.root - - - -1
+QCDCalcType            single   -   -   -   -1
+PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016 - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# BDT
+#-----------------------------------------------------------------------------------------------------------------------------
+BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Analysis year
+#-----------------------------------------------------------------------------------------------------------------------------
+AnalysisYear   2016postVFP  - - - -1
+#------------------------------------------------------------------------------------------------------
+# Electron ID
+#------------------------------------------------------------------------------------------------------
+electronIDType             HEEP  - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# B-tagging
+# See: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation
+#-----------------------------------------------------------------------------------------------------------------------------
+BTagAlgo       DeepJet  - - - -1
+#BTagWP         Loose    - - - -1
+#BTagCutValue   0.0480   - - - -1
+BTagWP         Medium   - - - -1
+BTagCutValue   0.2489   - - - -1
+#
+#-----------------------------------------------------------------------------------------------------------------------------
+#--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
+# The cut variable names, cut boundaries and histogram binnings are provided here by the user.
+# In the event loop of the analysisClass_template.C, the user have to fill each variable with its value using
+# a provided function call [ e.g. fillVariableWithValue("nEleFinal", number_of_electrons) ]
+# The variable names in the user code has to match the names provided here.
+# Variable names must be unique.
+# The cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )
+# in case only the first range (minValue1, maxValue1) is provided,
+# otherwise the cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )  OR  ( minValue2 < VariableName <= maxValue2 )
+# in case even the second range (minValue2, maxValue2) is provided.
+# The level of the cut (0,1,2 ... n) is provided by the user and can be used in the code to easily determine if
+# groups of same-level cuts have passed or failed.
+#
+#VariableName                   minValue1(<) maxValue1(>=)      minValue2(<)    maxValue2(>=)   level   histoNbinsMinMax      OptionalFlag
+#------------                   ------------ -------------      ------------    -------------   -----   ----------------      ------------
+#-----------------------------------------------------------------------------------------------------------------------------
+#                          _           _   _             
+# _ __  _ __ ___  ___  ___| | ___  ___| |_(_) ___  _ __  
+#| '_ \| '__/ _ \/ __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \ 
+#| |_) | | |  __/\__ \  __/ |  __/ (__| |_| | (_) | | | |
+#| .__/|_|  \___||___/\___|_|\___|\___|\__|_|\___/|_| |_|
+#|_|                    
+#-----------------------------------------------------------------------------------------------------------------------------
+Reweighting                        0              1              -           -           0           2             -0.5           1.5
+PassLHECuts                        0              1              -           -           0           2             -0.5           1.5
+PassJSON                           0              1              -           -           0           2             -0.5           1.5
+PassHLT                            0              1              -           -           0           2             -0.5           1.5
+PassGlobalSuperTightHalo2016Filter 0              1              -           -           0           2             -0.5           1.5
+PassGoodVertices                   0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseFilter                0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseIsoFilter             0              1              -           -           0           2             -0.5           1.5
+PassBadEESupercrystalFilter        0              1              -           -           0           2             -0.5           1.5
+PassEcalDeadCellTrigPrim           0              1              -           -           0           2             -0.5           1.5
+PassBadPFMuonFilter                0              1              -           -           0           2             -0.5           1.5
+PassEcalBadCalibFilter             0              1              -           -           0           2             -0.5           1.5
+PassNEle                           0              1              -           -           0           11            -0.5           10.5
+PassNMuon                          0              1              -           -           0           16            -0.5           15.5
+nEle_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+nJet_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+Ele1_Pt_skim                       40             +inf           -           -           0           200           0              2000
+Ele2_Pt_skim                       40             +inf           -           -           0           200           0              2000
+PassIDRequirements                 0              1              -           -           0           2             -0.5           1.5
+nJet                               -inf           +inf           -           -           0           16            -0.5           15.5
+Jet1_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet1_Eta                           -2.4           2.4            -           -           0           100           -5             5
+Jet2_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet2_Eta                           -2.4           2.4            -           -           0           100           -5             5
+DR_Ele1Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele1Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Jet1Jet2                        -inf           +inf           -           -           0           100           0              10
+PFMET_Type1_Pt                     -inf           +inf           -           -           0           200           0              20
+PFMET_Type1_Phi                    -inf           +inf           -           -           0           200           0              2000
+Ele1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.14
+Ele2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Ele1_Eta                           -inf           +inf           -           -           0           100           -5             5
+Ele2_Eta                           -inf           +inf           -           -           0           100           -5             5
+M_e1j1                             -inf           +inf           -           -           0           200           0              2000
+M_e1j2                             -inf           +inf           -           -           0           200           0              2000
+M_e2j1                             -inf           +inf           -           -           0           200           0              2000
+M_e2j2                             -inf           +inf           -           -           0           200           0              2000
+Jet3_Pt                            -inf           +inf           -           -           0           200           0              2000
+Jet3_Eta                           -inf           +inf           -           -           0           100           -5             5
+Jet1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet3_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Masym                              -inf           +inf           -           -           0           200           0              2000
+MejMin                             -inf           +inf           -           -           0           200           0              2000
+MejMax                             -inf           +inf           -           -           0           200           0              2000
+Meejj                              -inf           +inf           -           -           0           200           0              2000
+Pt_e1e2_skim                       50             +inf           -           -           0           200           0              2000
+sT_eejj_skim                       200            +inf           -           -           0           200           0              2000
+M_e1e2_skim                        40             +inf           -           -           0           200           0              2000
+skim_selection                     -inf           +inf           -           -           0           2             -0.5           1.5
+Ele1_Pt                            50             +inf           -           -           0           200           0              2000
+Ele2_Pt                            50             +inf           -           -           0           200           0              2000
+Jet1_Pt                            50             +inf           -           -           0           200           0              2000
+Jet2_Pt                            50             +inf           -           -           0           200           0              2000
+Pt_e1e2                            70             +inf           -           -           0           200           0              2000
+sT_eejj_bkgCR                      300            +inf           -           -           0           200           0              2000
+M_e1e2_bkgCR                       50             +inf           -           -           0           200           0              2000
+preselection                       -inf           +inf           -           -           0           2             -0.5           1.5
+sT_eejj                            400            +inf           -           -           0           200           0              2000
+M_e1e2                             220            +inf           -           -           0           200           0              2000
+trainingSelection                  -inf           +inf           -           -           1           2             -0.5           1.5
+#-----------------------------------------------------------------------------------------------------------------------------
+#  __ _             _            _           _   _                                                                        
+# / _(_)_ __   __ _| |  ___  ___| | ___  ___| |_(_) ___  _ __                                                             
+#| |_| | '_ \ / _` | | / __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \                                                            
+#|  _| | | | | (_| | | \__ \  __/ |  __/ (__| |_| | (_) | | | |                                                           
+#|_| |_|_| |_|\__,_|_| |___/\___|_|\___|\___|\__|_|\___/|_| |_|                                                           
+#-----------------------------------------------------------------------------------------------------------------------------
+# CUTS GET PROGRESSIVELY TIGHTER
+##------------------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 3000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ3000                         -0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2900                         -0.8408                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2800                         -0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2600                         -0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         -0.04                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2500                         0.3203                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ300                         0.4204                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2400                         0.5405                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ400                         0.6006                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2300                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2200                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ500                         0.8208                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.8408                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2000                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ700                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ600                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1500                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1600                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection

--- a/config2016/Analysis/postVFP/powheg-amcatnlo/cutTable_lq_eejj_QCD_singleFR.txt
+++ b/config2016/Analysis/postVFP/powheg-amcatnlo/cutTable_lq_eejj_QCD_singleFR.txt
@@ -28,61 +28,61 @@ PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016 - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # BDT
 #-----------------------------------------------------------------------------------------------------------------------------
-BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016postVFP/powheg-amcatnlo/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # Analysis year
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/config2016/Analysis/preVFP/HTLO-amcatnlo/cutTable_lq_eejj_BDT.txt
+++ b/config2016/Analysis/preVFP/HTLO-amcatnlo/cutTable_lq_eejj_BDT.txt
@@ -20,88 +20,104 @@ eleEta_bar            1.4442           -                -               -       
 eleEta_end1           1.566            2.0              -               -               -1
 eleEta_end2           2.000            2.5              -               -               -1
 #-----------------------------------------------------------------------------------------------------------------------------
-# Fake rates
-#-----------------------------------------------------------------------------------------------------------------------------
-QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016postVFP/fr2DpostVFP.root - - - -1
-QCDCalcType            single   -   -   -   -1
-PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016 - - - -1
-#-----------------------------------------------------------------------------------------------------------------------------
 # BDT
 #-----------------------------------------------------------------------------------------------------------------------------
-BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # Analysis year
 #-----------------------------------------------------------------------------------------------------------------------------
-AnalysisYear   2016postVFP  - - - -1
-#------------------------------------------------------------------------------------------------------
-# Electron ID
-#------------------------------------------------------------------------------------------------------
-electronIDType             HEEP  - - - -1
+AnalysisYear   2016  - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # B-tagging
 # See: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation
 #-----------------------------------------------------------------------------------------------------------------------------
 BTagAlgo       DeepJet  - - - -1
 #BTagWP         Loose    - - - -1
-#BTagCutValue   0.0480   - - - -1
+#BTagCutValue   0.0508   - - - -1
 BTagWP         Medium   - - - -1
-BTagCutValue   0.2489   - - - -1
+BTagCutValue   0.2598   - - - -1
 #
 #-----------------------------------------------------------------------------------------------------------------------------
+# systematics
+#-----------------------------------------------------------------------------------------------------------------------------
+#         name              source/formula/branch                                       cutVars
+#         ------------      ------------------------------------------------------      --------------------------------------
+#SYST      FivePercentUp     1.05
+SYST      PrefireDown       PrefireWeight_Dn/PrefireWeight
+SYST      PrefireUp         PrefireWeight_Up/PrefireWeight
+SYST      JERDown           regex=".+jerdown.*"                                         sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JERUp             regex=".+jerup.*"                                           sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JESDown           regex=".+jesTotaldown.*"                                    sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JESUp             regex=".+jesTotalup.*"                                      sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+#FIXME: EER/EES effect on MET?
+SYST      EERDown           regex=".+EER_Dn.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EERUp             regex=".+EER_Up.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EESDown           regex=".+EES_Dn.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EESUp             regex=".+EES_Up.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EleRecoSFUp       (Ele1_RecoSF_Up/Ele1_RecoSF)*(Ele2_RecoSF_Up/Ele2_RecoSF)
+SYST      EleRecoSFDown     (Ele1_RecoSF_Dn/Ele1_RecoSF)*(Ele2_RecoSF_Dn/Ele2_RecoSF)
+SYST      EleIDSFUp         ((Ele1_HEEPSF+Ele1_HEEPSF_Err)/Ele1_HEEPSF)*((Ele2_HEEPSF+Ele2_HEEPSF_Err)/Ele2_HEEPSF)
+SYST      EleIDSFDown       ((Ele1_HEEPSF-Ele1_HEEPSF_Err)/Ele1_HEEPSF)*((Ele2_HEEPSF-Ele2_HEEPSF_Err)/Ele2_HEEPSF)
+SYST      EleTrigSFUp       
+SYST      EleTrigSFDown     
+SYST      PileupUp          puWeight_Up/puWeight
+SYST      PileupDown        puWeight_Dn/puWeight
+SYST      LHEPdfWeight      LHEPdfWeight
+SYST      LHEScaleWeight    LHEScaleWeight
 #--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
 # The cut variable names, cut boundaries and histogram binnings are provided here by the user.
 # In the event loop of the analysisClass_template.C, the user have to fill each variable with its value using
@@ -145,7 +161,6 @@ nEle_hltMatched                    -inf           +inf           -           -  
 nJet_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
 Ele1_Pt_skim                       40             +inf           -           -           0           200           0              2000
 Ele2_Pt_skim                       40             +inf           -           -           0           200           0              2000
-PassIDRequirements                 0              1              -           -           0           2             -0.5           1.5
 nJet                               -inf           +inf           -           -           0           16            -0.5           15.5
 Jet1_Pt_skim                       35             +inf           -           -           0           200           0              2000
 Jet1_Eta                           -2.4           2.4            -           -           0           100           -5             5
@@ -186,9 +201,9 @@ Jet2_Pt                            50             +inf           -           -  
 Pt_e1e2                            70             +inf           -           -           0           200           0              2000
 sT_eejj_bkgCR                      300            +inf           -           -           0           200           0              2000
 M_e1e2_bkgCR                       50             +inf           -           -           0           200           0              2000
-preselection                       -inf           +inf           -           -           0           2             -0.5           1.5
-sT_eejj                            400            +inf           -           -           0           200           0              2000
-M_e1e2                             220            +inf           -           -           0           200           0              2000
+preselection                       -inf           +inf           -           -           0           2             -0.5           1.5     SYSTS
+sT_eejj                            400            +inf           -           -           0           200           0              2000    SYSTS
+M_e1e2                             220            +inf           -           -           0           200           0              2000    SYSTS
 trainingSelection                  -inf           +inf           -           -           1           2             -0.5           1.5
 #-----------------------------------------------------------------------------------------------------------------------------
 #  __ _             _            _           _   _                                                                        
@@ -202,103 +217,83 @@ trainingSelection                  -inf           +inf           -           -  
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 3000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ3000                         -0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2900                         -0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+BDTOutput_LQ3000                         -0.5005                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2800                         -0.6807                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+BDTOutput_LQ2800                         -0.0601                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2600 optimization
+# LQ M 2900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2600                         -0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+BDTOutput_LQ2900                         0.2002                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2700 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2700                         -0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2500 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2500                         -0.1602                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2300 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2300                         0.3003                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+BDTOutput_LQ2700                         0.3003                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ300                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+BDTOutput_LQ300                         0.3203                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2400 optimization
+# LQ M 2600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2400                         0.3604                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2200 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2200                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+BDTOutput_LQ2600                         0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ400                         0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+BDTOutput_LQ400                         0.5606                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2100 optimization
+# LQ M 2500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2100                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+BDTOutput_LQ2500                         0.6807                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ500                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+BDTOutput_LQ500                         0.8208                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2000 optimization
+# LQ M 2400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2000                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+BDTOutput_LQ2400                         0.8609                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1900 optimization
+# LQ M 2300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1900                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+BDTOutput_LQ2300                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ600                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 800 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+BDTOutput_LQ600                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 700 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1800 optimization
+# LQ M 2200 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+BDTOutput_LQ2200                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1600 optimization
+# LQ M 800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1600                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+BDTOutput_LQ800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1700 optimization
+# LQ M 2000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 1000 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
+BDTOutput_LQ2000                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 900 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1100 optimization
+# LQ M 1000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1200 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1400 optimization
 #------------------------------------------------------------------------------------------------------------------
@@ -308,6 +303,26 @@ BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 1600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1600                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 1500 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1500                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection

--- a/config2016/Analysis/preVFP/HTLO-amcatnlo/cutTable_lq_eejj_QCD_doubleFR.txt
+++ b/config2016/Analysis/preVFP/HTLO-amcatnlo/cutTable_lq_eejj_QCD_doubleFR.txt
@@ -22,71 +22,71 @@ eleEta_end2           2.000            2.5              -               -       
 #-----------------------------------------------------------------------------------------------------------------------------
 # Fake rates
 #-----------------------------------------------------------------------------------------------------------------------------
-QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016postVFP/fr2DpostVFP.root - - - -1
-QCDCalcType            single   -   -   -   -1
+QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016preVFP/fr2DpreVFP.root - - - -1
+QCDCalcType            double   -   -   -   -1
 PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016 - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # BDT
 #-----------------------------------------------------------------------------------------------------------------------------
-BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # Analysis year
 #-----------------------------------------------------------------------------------------------------------------------------
-AnalysisYear   2016postVFP  - - - -1
+AnalysisYear   2016preVFP  - - - -1
 #------------------------------------------------------------------------------------------------------
 # Electron ID
 #------------------------------------------------------------------------------------------------------
@@ -97,9 +97,9 @@ electronIDType             HEEP  - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 BTagAlgo       DeepJet  - - - -1
 #BTagWP         Loose    - - - -1
-#BTagCutValue   0.0480   - - - -1
+#BTagCutValue   0.0508   - - - -1
 BTagWP         Medium   - - - -1
-BTagCutValue   0.2489   - - - -1
+BTagCutValue   0.2598   - - - -1
 #
 #-----------------------------------------------------------------------------------------------------------------------------
 #--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
@@ -202,103 +202,83 @@ trainingSelection                  -inf           +inf           -           -  
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 3000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ3000                         -0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2900                         -0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+BDTOutput_LQ3000                         -0.5005                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2800                         -0.6807                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+BDTOutput_LQ2800                         -0.0601                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2600 optimization
+# LQ M 2900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2600                         -0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+BDTOutput_LQ2900                         0.2002                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2700 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2700                         -0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2500 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2500                         -0.1602                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2300 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2300                         0.3003                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+BDTOutput_LQ2700                         0.3003                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ300                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+BDTOutput_LQ300                         0.3203                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2400 optimization
+# LQ M 2600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2400                         0.3604                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2200 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2200                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+BDTOutput_LQ2600                         0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ400                         0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+BDTOutput_LQ400                         0.5606                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2100 optimization
+# LQ M 2500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2100                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+BDTOutput_LQ2500                         0.6807                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ500                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+BDTOutput_LQ500                         0.8208                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2000 optimization
+# LQ M 2400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2000                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+BDTOutput_LQ2400                         0.8609                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1900 optimization
+# LQ M 2300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1900                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+BDTOutput_LQ2300                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ600                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 800 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+BDTOutput_LQ600                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 700 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1800 optimization
+# LQ M 2200 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+BDTOutput_LQ2200                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1600 optimization
+# LQ M 800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1600                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+BDTOutput_LQ800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1700 optimization
+# LQ M 2000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 1000 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
+BDTOutput_LQ2000                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 900 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1100 optimization
+# LQ M 1000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1200 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1400 optimization
 #------------------------------------------------------------------------------------------------------------------
@@ -308,6 +288,26 @@ BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 1600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1600                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 1500 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1500                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection

--- a/config2016/Analysis/preVFP/HTLO-amcatnlo/cutTable_lq_eejj_QCD_singleFR.txt
+++ b/config2016/Analysis/preVFP/HTLO-amcatnlo/cutTable_lq_eejj_QCD_singleFR.txt
@@ -22,71 +22,71 @@ eleEta_end2           2.000            2.5              -               -       
 #-----------------------------------------------------------------------------------------------------------------------------
 # Fake rates
 #-----------------------------------------------------------------------------------------------------------------------------
-QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016postVFP/fr2DpostVFP.root - - - -1
+QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016preVFP/fr2DpreVFP.root - - - -1
 QCDCalcType            single   -   -   -   -1
 PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016 - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # BDT
 #-----------------------------------------------------------------------------------------------------------------------------
-BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # Analysis year
 #-----------------------------------------------------------------------------------------------------------------------------
-AnalysisYear   2016postVFP  - - - -1
+AnalysisYear   2016preVFP  - - - -1
 #------------------------------------------------------------------------------------------------------
 # Electron ID
 #------------------------------------------------------------------------------------------------------
@@ -97,9 +97,9 @@ electronIDType             HEEP  - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 BTagAlgo       DeepJet  - - - -1
 #BTagWP         Loose    - - - -1
-#BTagCutValue   0.0480   - - - -1
+#BTagCutValue   0.0508   - - - -1
 BTagWP         Medium   - - - -1
-BTagCutValue   0.2489   - - - -1
+BTagCutValue   0.2598   - - - -1
 #
 #-----------------------------------------------------------------------------------------------------------------------------
 #--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
@@ -202,103 +202,83 @@ trainingSelection                  -inf           +inf           -           -  
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 3000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ3000                         -0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2900                         -0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+BDTOutput_LQ3000                         -0.5005                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2800                         -0.6807                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+BDTOutput_LQ2800                         -0.0601                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2600 optimization
+# LQ M 2900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2600                         -0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+BDTOutput_LQ2900                         0.2002                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2700 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2700                         -0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2500 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2500                         -0.1602                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2300 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2300                         0.3003                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+BDTOutput_LQ2700                         0.3003                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ300                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+BDTOutput_LQ300                         0.3203                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2400 optimization
+# LQ M 2600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2400                         0.3604                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2200 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2200                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+BDTOutput_LQ2600                         0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ400                         0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+BDTOutput_LQ400                         0.5606                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2100 optimization
+# LQ M 2500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2100                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+BDTOutput_LQ2500                         0.6807                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ500                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+BDTOutput_LQ500                         0.8208                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2000 optimization
+# LQ M 2400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2000                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+BDTOutput_LQ2400                         0.8609                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1900 optimization
+# LQ M 2300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1900                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+BDTOutput_LQ2300                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ600                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 800 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+BDTOutput_LQ600                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 700 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1800 optimization
+# LQ M 2200 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+BDTOutput_LQ2200                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1600 optimization
+# LQ M 800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1600                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+BDTOutput_LQ800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1700 optimization
+# LQ M 2000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 1000 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
+BDTOutput_LQ2000                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 900 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1100 optimization
+# LQ M 1000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1200 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1400 optimization
 #------------------------------------------------------------------------------------------------------------------
@@ -308,6 +288,26 @@ BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 1600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1600                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 1500 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1500                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection

--- a/config2016/Analysis/preVFP/ignoreNegWeights/cutTable_lq_eejj_BDT.txt
+++ b/config2016/Analysis/preVFP/ignoreNegWeights/cutTable_lq_eejj_BDT.txt
@@ -1,0 +1,329 @@
+#############################     Example of file with list of cuts
+#
+#
+#------------------------ Preliminary cut variables and values (cut level -1) here -----------------------------
+# This first list of variable names and values are used to pass configurable values to the user code associated
+# to a variable name.
+# The user can retrieve the values associated to a variable name via a provided function call
+# [e.g. getPreCutValue1("eleFidRegion") and similarly for value2, value3 and value4 ]
+# The idea is that the user can use these values to define the list of objects (electrons, jets, etc.) used in
+# analysis. No cut is automatically evaluated on these variables and the cut level must be equal to -1.
+# Variable names must be unique.
+#
+#VariableName         value1            value2          value3          value4          level
+#------------         ------------      -------------   ------------    -------------   -----
+produceSkim           1                 -               -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Preselection cuts
+#-----------------------------------------------------------------------------------------------------------------------------
+eleEta_bar            1.4442           -                -               -               -1
+eleEta_end1           1.566            2.0              -               -               -1
+eleEta_end2           2.000            2.5              -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# BDT
+#-----------------------------------------------------------------------------------------------------------------------------
+BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+#-----------------------------------------------------------------------------------------------------------------------------
+# Analysis year
+#-----------------------------------------------------------------------------------------------------------------------------
+AnalysisYear   2016  - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# B-tagging
+# See: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation
+#-----------------------------------------------------------------------------------------------------------------------------
+BTagAlgo       DeepJet  - - - -1
+#BTagWP         Loose    - - - -1
+#BTagCutValue   0.0508   - - - -1
+BTagWP         Medium   - - - -1
+BTagCutValue   0.2598   - - - -1
+#
+#-----------------------------------------------------------------------------------------------------------------------------
+# systematics
+#-----------------------------------------------------------------------------------------------------------------------------
+#         name              source/formula/branch                                       cutVars
+#         ------------      ------------------------------------------------------      --------------------------------------
+#SYST      FivePercentUp     1.05
+SYST      PrefireDown       PrefireWeight_Dn/PrefireWeight
+SYST      PrefireUp         PrefireWeight_Up/PrefireWeight
+SYST      JERDown           regex=".+jerdown.*"                                         sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JERUp             regex=".+jerup.*"                                           sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JESDown           regex=".+jesTotaldown.*"                                    sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JESUp             regex=".+jesTotalup.*"                                      sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+#FIXME: EER/EES effect on MET?
+SYST      EERDown           regex=".+EER_Dn.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EERUp             regex=".+EER_Up.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EESDown           regex=".+EES_Dn.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EESUp             regex=".+EES_Up.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EleRecoSFUp       (Ele1_RecoSF_Up/Ele1_RecoSF)*(Ele2_RecoSF_Up/Ele2_RecoSF)
+SYST      EleRecoSFDown     (Ele1_RecoSF_Dn/Ele1_RecoSF)*(Ele2_RecoSF_Dn/Ele2_RecoSF)
+SYST      EleIDSFUp         ((Ele1_HEEPSF+Ele1_HEEPSF_Err)/Ele1_HEEPSF)*((Ele2_HEEPSF+Ele2_HEEPSF_Err)/Ele2_HEEPSF)
+SYST      EleIDSFDown       ((Ele1_HEEPSF-Ele1_HEEPSF_Err)/Ele1_HEEPSF)*((Ele2_HEEPSF-Ele2_HEEPSF_Err)/Ele2_HEEPSF)
+SYST      EleTrigSFUp       
+SYST      EleTrigSFDown     
+SYST      PileupUp          puWeight_Up/puWeight
+SYST      PileupDown        puWeight_Dn/puWeight
+SYST      LHEPdfWeight      LHEPdfWeight
+SYST      LHEScaleWeight    LHEScaleWeight
+#--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
+# The cut variable names, cut boundaries and histogram binnings are provided here by the user.
+# In the event loop of the analysisClass_template.C, the user have to fill each variable with its value using
+# a provided function call [ e.g. fillVariableWithValue("nEleFinal", number_of_electrons) ]
+# The variable names in the user code has to match the names provided here.
+# Variable names must be unique.
+# The cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )
+# in case only the first range (minValue1, maxValue1) is provided,
+# otherwise the cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )  OR  ( minValue2 < VariableName <= maxValue2 )
+# in case even the second range (minValue2, maxValue2) is provided.
+# The level of the cut (0,1,2 ... n) is provided by the user and can be used in the code to easily determine if
+# groups of same-level cuts have passed or failed.
+#
+#VariableName                   minValue1(<) maxValue1(>=)      minValue2(<)    maxValue2(>=)   level   histoNbinsMinMax      OptionalFlag
+#------------                   ------------ -------------      ------------    -------------   -----   ----------------      ------------
+#-----------------------------------------------------------------------------------------------------------------------------
+#                          _           _   _             
+# _ __  _ __ ___  ___  ___| | ___  ___| |_(_) ___  _ __  
+#| '_ \| '__/ _ \/ __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \ 
+#| |_) | | |  __/\__ \  __/ |  __/ (__| |_| | (_) | | | |
+#| .__/|_|  \___||___/\___|_|\___|\___|\__|_|\___/|_| |_|
+#|_|                    
+#-----------------------------------------------------------------------------------------------------------------------------
+Reweighting                        0              1              -           -           0           2             -0.5           1.5
+PassLHECuts                        0              1              -           -           0           2             -0.5           1.5
+PassJSON                           0              1              -           -           0           2             -0.5           1.5
+PassHLT                            0              1              -           -           0           2             -0.5           1.5
+PassGlobalSuperTightHalo2016Filter 0              1              -           -           0           2             -0.5           1.5
+PassGoodVertices                   0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseFilter                0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseIsoFilter             0              1              -           -           0           2             -0.5           1.5
+PassBadEESupercrystalFilter        0              1              -           -           0           2             -0.5           1.5
+PassEcalDeadCellTrigPrim           0              1              -           -           0           2             -0.5           1.5
+PassBadPFMuonFilter                0              1              -           -           0           2             -0.5           1.5
+PassEcalBadCalibFilter             0              1              -           -           0           2             -0.5           1.5
+PassNEle                           0              1              -           -           0           11            -0.5           10.5
+PassNMuon                          0              1              -           -           0           16            -0.5           15.5
+nEle_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+nJet_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+Ele1_Pt_skim                       40             +inf           -           -           0           200           0              2000
+Ele2_Pt_skim                       40             +inf           -           -           0           200           0              2000
+nJet                               -inf           +inf           -           -           0           16            -0.5           15.5
+Jet1_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet1_Eta                           -2.4           2.4            -           -           0           100           -5             5
+Jet2_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet2_Eta                           -2.4           2.4            -           -           0           100           -5             5
+DR_Ele1Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele1Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Jet1Jet2                        -inf           +inf           -           -           0           100           0              10
+PFMET_Type1_Pt                     -inf           +inf           -           -           0           200           0              20
+PFMET_Type1_Phi                    -inf           +inf           -           -           0           200           0              2000
+Ele1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.14
+Ele2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Ele1_Eta                           -inf           +inf           -           -           0           100           -5             5
+Ele2_Eta                           -inf           +inf           -           -           0           100           -5             5
+M_e1j1                             -inf           +inf           -           -           0           200           0              2000
+M_e1j2                             -inf           +inf           -           -           0           200           0              2000
+M_e2j1                             -inf           +inf           -           -           0           200           0              2000
+M_e2j2                             -inf           +inf           -           -           0           200           0              2000
+Jet3_Pt                            -inf           +inf           -           -           0           200           0              2000
+Jet3_Eta                           -inf           +inf           -           -           0           100           -5             5
+Jet1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet3_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Masym                              -inf           +inf           -           -           0           200           0              2000
+MejMin                             -inf           +inf           -           -           0           200           0              2000
+MejMax                             -inf           +inf           -           -           0           200           0              2000
+Meejj                              -inf           +inf           -           -           0           200           0              2000
+Pt_e1e2_skim                       50             +inf           -           -           0           200           0              2000
+sT_eejj_skim                       200            +inf           -           -           0           200           0              2000
+M_e1e2_skim                        40             +inf           -           -           0           200           0              2000
+skim_selection                     -inf           +inf           -           -           0           2             -0.5           1.5
+Ele1_Pt                            50             +inf           -           -           0           200           0              2000
+Ele2_Pt                            50             +inf           -           -           0           200           0              2000
+Jet1_Pt                            50             +inf           -           -           0           200           0              2000
+Jet2_Pt                            50             +inf           -           -           0           200           0              2000
+Pt_e1e2                            70             +inf           -           -           0           200           0              2000
+sT_eejj_bkgCR                      300            +inf           -           -           0           200           0              2000
+M_e1e2_bkgCR                       50             +inf           -           -           0           200           0              2000
+preselection                       -inf           +inf           -           -           0           2             -0.5           1.5     SYSTS
+sT_eejj                            400            +inf           -           -           0           200           0              2000    SYSTS
+M_e1e2                             220            +inf           -           -           0           200           0              2000    SYSTS
+trainingSelection                  -inf           +inf           -           -           1           2             -0.5           1.5
+#-----------------------------------------------------------------------------------------------------------------------------
+#  __ _             _            _           _   _                                                                        
+# / _(_)_ __   __ _| |  ___  ___| | ___  ___| |_(_) ___  _ __                                                             
+#| |_| | '_ \ / _` | | / __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \                                                            
+#|  _| | | | | (_| | | \__ \  __/ |  __/ (__| |_| | (_) | | | |                                                           
+#|_| |_|_| |_|\__,_|_| |___/\___|_|\___|\___|\__|_|\___/|_| |_|                                                           
+#-----------------------------------------------------------------------------------------------------------------------------
+# CUTS GET PROGRESSIVELY TIGHTER
+##------------------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 3000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ3000                         -0.8208                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2800                         -0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2900                         -0.3203                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ300                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2600                         0.3804                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ400                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ500                         0.6607                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2500                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2300                         0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2400                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ600                         0.8408                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2200                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2000                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1600                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1500                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection

--- a/config2016/Analysis/preVFP/ignoreNegWeights/cutTable_lq_eejj_BDT.txt
+++ b/config2016/Analysis/preVFP/ignoreNegWeights/cutTable_lq_eejj_BDT.txt
@@ -22,62 +22,61 @@ eleEta_end2           2.000            2.5              -               -       
 #-----------------------------------------------------------------------------------------------------------------------------
 # BDT
 #-----------------------------------------------------------------------------------------------------------------------------
-BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
-
+BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # Analysis year
 #-----------------------------------------------------------------------------------------------------------------------------
@@ -216,97 +215,89 @@ trainingSelection                  -inf           +inf           -           -  
 # CUTS GET PROGRESSIVELY TIGHTER
 ##------------------------------------------------------------------------------------------------
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         -0.2803                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 3000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ3000                         -0.8208                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
+BDTOutput_LQ3000                         -0.2603                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2800                         -0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2900                         -0.3203                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+BDTOutput_LQ2800                         0.02                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ300                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+BDTOutput_LQ300                         0.0801                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2700 optimization
+# LQ M 2900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2700                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+BDTOutput_LQ2900                         0.2002                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2600                         0.3804                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+BDTOutput_LQ2600                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ400                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 500 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ500                         0.6607                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+BDTOutput_LQ400                         0.5806                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2500                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
+BDTOutput_LQ2500                         0.6406                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2300 optimization
+# LQ M 500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2300                         0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2400 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2400                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+BDTOutput_LQ500                         0.6807                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ600                         0.8408                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+BDTOutput_LQ600                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2200 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2200                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+BDTOutput_LQ2200                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2000 optimization
+# LQ M 2400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2000                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+BDTOutput_LQ2400                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 700 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2100 optimization
+# LQ M 2300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2100                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+BDTOutput_LQ2300                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1800 optimization
+# LQ M 800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+BDTOutput_LQ800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1700 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 2000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2000                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 1900 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1900                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 800 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 1000 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 900 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1200 optimization
+# LQ M 1000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1100 optimization
 #------------------------------------------------------------------------------------------------------------------
@@ -320,9 +311,17 @@ BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 1200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 1600 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1600                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1500 optimization
 #------------------------------------------------------------------------------------------------------------------

--- a/config2016/Analysis/preVFP/ignoreNegWeights/cutTable_lq_eejj_QCD_doubleFR.txt
+++ b/config2016/Analysis/preVFP/ignoreNegWeights/cutTable_lq_eejj_QCD_doubleFR.txt
@@ -1,0 +1,313 @@
+#############################     Example of file with list of cuts
+#
+#
+#------------------------ Preliminary cut variables and values (cut level -1) here -----------------------------
+# This first list of variable names and values are used to pass configurable values to the user code associated
+# to a variable name.
+# The user can retrieve the values associated to a variable name via a provided function call
+# [e.g. getPreCutValue1("eleFidRegion") and similarly for value2, value3 and value4 ]
+# The idea is that the user can use these values to define the list of objects (electrons, jets, etc.) used in
+# analysis. No cut is automatically evaluated on these variables and the cut level must be equal to -1.
+# Variable names must be unique.
+#
+#VariableName         value1            value2          value3          value4          level
+#------------         ------------      -------------   ------------    -------------   -----
+produceSkim           1                 -               -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Preselection cuts
+#-----------------------------------------------------------------------------------------------------------------------------
+eleEta_bar            1.4442           -                -               -               -1
+eleEta_end1           1.566            2.0              -               -               -1
+eleEta_end2           2.000            2.5              -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Fake rates
+#-----------------------------------------------------------------------------------------------------------------------------
+QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016preVFP/fr2DpreVFP.root - - - -1
+QCDCalcType            double   -   -   -   -1
+PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016 - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# BDT
+#-----------------------------------------------------------------------------------------------------------------------------
+BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Analysis year
+#-----------------------------------------------------------------------------------------------------------------------------
+AnalysisYear   2016preVFP  - - - -1
+#------------------------------------------------------------------------------------------------------
+# Electron ID
+#------------------------------------------------------------------------------------------------------
+electronIDType             HEEP  - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# B-tagging
+# See: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation
+#-----------------------------------------------------------------------------------------------------------------------------
+BTagAlgo       DeepJet  - - - -1
+#BTagWP         Loose    - - - -1
+#BTagCutValue   0.0508   - - - -1
+BTagWP         Medium   - - - -1
+BTagCutValue   0.2598   - - - -1
+#
+#-----------------------------------------------------------------------------------------------------------------------------
+#--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
+# The cut variable names, cut boundaries and histogram binnings are provided here by the user.
+# In the event loop of the analysisClass_template.C, the user have to fill each variable with its value using
+# a provided function call [ e.g. fillVariableWithValue("nEleFinal", number_of_electrons) ]
+# The variable names in the user code has to match the names provided here.
+# Variable names must be unique.
+# The cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )
+# in case only the first range (minValue1, maxValue1) is provided,
+# otherwise the cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )  OR  ( minValue2 < VariableName <= maxValue2 )
+# in case even the second range (minValue2, maxValue2) is provided.
+# The level of the cut (0,1,2 ... n) is provided by the user and can be used in the code to easily determine if
+# groups of same-level cuts have passed or failed.
+#
+#VariableName                   minValue1(<) maxValue1(>=)      minValue2(<)    maxValue2(>=)   level   histoNbinsMinMax      OptionalFlag
+#------------                   ------------ -------------      ------------    -------------   -----   ----------------      ------------
+#-----------------------------------------------------------------------------------------------------------------------------
+#                          _           _   _             
+# _ __  _ __ ___  ___  ___| | ___  ___| |_(_) ___  _ __  
+#| '_ \| '__/ _ \/ __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \ 
+#| |_) | | |  __/\__ \  __/ |  __/ (__| |_| | (_) | | | |
+#| .__/|_|  \___||___/\___|_|\___|\___|\__|_|\___/|_| |_|
+#|_|                    
+#-----------------------------------------------------------------------------------------------------------------------------
+Reweighting                        0              1              -           -           0           2             -0.5           1.5
+PassLHECuts                        0              1              -           -           0           2             -0.5           1.5
+PassJSON                           0              1              -           -           0           2             -0.5           1.5
+PassHLT                            0              1              -           -           0           2             -0.5           1.5
+PassGlobalSuperTightHalo2016Filter 0              1              -           -           0           2             -0.5           1.5
+PassGoodVertices                   0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseFilter                0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseIsoFilter             0              1              -           -           0           2             -0.5           1.5
+PassBadEESupercrystalFilter        0              1              -           -           0           2             -0.5           1.5
+PassEcalDeadCellTrigPrim           0              1              -           -           0           2             -0.5           1.5
+PassBadPFMuonFilter                0              1              -           -           0           2             -0.5           1.5
+PassEcalBadCalibFilter             0              1              -           -           0           2             -0.5           1.5
+PassNEle                           0              1              -           -           0           11            -0.5           10.5
+PassNMuon                          0              1              -           -           0           16            -0.5           15.5
+nEle_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+nJet_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+Ele1_Pt_skim                       40             +inf           -           -           0           200           0              2000
+Ele2_Pt_skim                       40             +inf           -           -           0           200           0              2000
+PassIDRequirements                 0              1              -           -           0           2             -0.5           1.5
+nJet                               -inf           +inf           -           -           0           16            -0.5           15.5
+Jet1_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet1_Eta                           -2.4           2.4            -           -           0           100           -5             5
+Jet2_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet2_Eta                           -2.4           2.4            -           -           0           100           -5             5
+DR_Ele1Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele1Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Jet1Jet2                        -inf           +inf           -           -           0           100           0              10
+PFMET_Type1_Pt                     -inf           +inf           -           -           0           200           0              20
+PFMET_Type1_Phi                    -inf           +inf           -           -           0           200           0              2000
+Ele1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.14
+Ele2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Ele1_Eta                           -inf           +inf           -           -           0           100           -5             5
+Ele2_Eta                           -inf           +inf           -           -           0           100           -5             5
+M_e1j1                             -inf           +inf           -           -           0           200           0              2000
+M_e1j2                             -inf           +inf           -           -           0           200           0              2000
+M_e2j1                             -inf           +inf           -           -           0           200           0              2000
+M_e2j2                             -inf           +inf           -           -           0           200           0              2000
+Jet3_Pt                            -inf           +inf           -           -           0           200           0              2000
+Jet3_Eta                           -inf           +inf           -           -           0           100           -5             5
+Jet1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet3_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Masym                              -inf           +inf           -           -           0           200           0              2000
+MejMin                             -inf           +inf           -           -           0           200           0              2000
+MejMax                             -inf           +inf           -           -           0           200           0              2000
+Meejj                              -inf           +inf           -           -           0           200           0              2000
+Pt_e1e2_skim                       50             +inf           -           -           0           200           0              2000
+sT_eejj_skim                       200            +inf           -           -           0           200           0              2000
+M_e1e2_skim                        40             +inf           -           -           0           200           0              2000
+skim_selection                     -inf           +inf           -           -           0           2             -0.5           1.5
+Ele1_Pt                            50             +inf           -           -           0           200           0              2000
+Ele2_Pt                            50             +inf           -           -           0           200           0              2000
+Jet1_Pt                            50             +inf           -           -           0           200           0              2000
+Jet2_Pt                            50             +inf           -           -           0           200           0              2000
+Pt_e1e2                            70             +inf           -           -           0           200           0              2000
+sT_eejj_bkgCR                      300            +inf           -           -           0           200           0              2000
+M_e1e2_bkgCR                       50             +inf           -           -           0           200           0              2000
+preselection                       -inf           +inf           -           -           0           2             -0.5           1.5
+sT_eejj                            400            +inf           -           -           0           200           0              2000
+M_e1e2                             220            +inf           -           -           0           200           0              2000
+trainingSelection                  -inf           +inf           -           -           1           2             -0.5           1.5
+#-----------------------------------------------------------------------------------------------------------------------------
+#  __ _             _            _           _   _                                                                        
+# / _(_)_ __   __ _| |  ___  ___| | ___  ___| |_(_) ___  _ __                                                             
+#| |_| | '_ \ / _` | | / __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \                                                            
+#|  _| | | | | (_| | | \__ \  __/ |  __/ (__| |_| | (_) | | | |                                                           
+#|_| |_|_| |_|\__,_|_| |___/\___|_|\___|\___|\__|_|\___/|_| |_|                                                           
+#-----------------------------------------------------------------------------------------------------------------------------
+# CUTS GET PROGRESSIVELY TIGHTER
+##------------------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 3000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ3000                         -0.8208                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2800                         -0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2900                         -0.3203                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ300                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2600                         0.3804                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ400                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ500                         0.6607                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2500                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2300                         0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2400                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ600                         0.8408                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2200                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2000                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1600                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1500                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection

--- a/config2016/Analysis/preVFP/ignoreNegWeights/cutTable_lq_eejj_QCD_doubleFR.txt
+++ b/config2016/Analysis/preVFP/ignoreNegWeights/cutTable_lq_eejj_QCD_doubleFR.txt
@@ -28,61 +28,61 @@ PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016 - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # BDT
 #-----------------------------------------------------------------------------------------------------------------------------
-BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # Analysis year
 #-----------------------------------------------------------------------------------------------------------------------------
@@ -200,97 +200,89 @@ trainingSelection                  -inf           +inf           -           -  
 # CUTS GET PROGRESSIVELY TIGHTER
 ##------------------------------------------------------------------------------------------------
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         -0.2803                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 3000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ3000                         -0.8208                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
+BDTOutput_LQ3000                         -0.2603                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2800                         -0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2900                         -0.3203                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+BDTOutput_LQ2800                         0.02                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ300                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+BDTOutput_LQ300                         0.0801                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2700 optimization
+# LQ M 2900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2700                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+BDTOutput_LQ2900                         0.2002                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2600                         0.3804                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+BDTOutput_LQ2600                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ400                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 500 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ500                         0.6607                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+BDTOutput_LQ400                         0.5806                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2500                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
+BDTOutput_LQ2500                         0.6406                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2300 optimization
+# LQ M 500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2300                         0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2400 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2400                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+BDTOutput_LQ500                         0.6807                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ600                         0.8408                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+BDTOutput_LQ600                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2200 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2200                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+BDTOutput_LQ2200                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2000 optimization
+# LQ M 2400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2000                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+BDTOutput_LQ2400                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 700 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2100 optimization
+# LQ M 2300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2100                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+BDTOutput_LQ2300                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1800 optimization
+# LQ M 800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+BDTOutput_LQ800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1700 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 2000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2000                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 1900 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1900                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 800 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 1000 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 900 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1200 optimization
+# LQ M 1000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1100 optimization
 #------------------------------------------------------------------------------------------------------------------
@@ -304,9 +296,17 @@ BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 1200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 1600 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1600                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1500 optimization
 #------------------------------------------------------------------------------------------------------------------

--- a/config2016/Analysis/preVFP/ignoreNegWeights/cutTable_lq_eejj_QCD_singleFR.txt
+++ b/config2016/Analysis/preVFP/ignoreNegWeights/cutTable_lq_eejj_QCD_singleFR.txt
@@ -28,61 +28,61 @@ PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016 - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # BDT
 #-----------------------------------------------------------------------------------------------------------------------------
-BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/amcatnloIgnore_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # Analysis year
 #-----------------------------------------------------------------------------------------------------------------------------
@@ -200,97 +200,89 @@ trainingSelection                  -inf           +inf           -           -  
 # CUTS GET PROGRESSIVELY TIGHTER
 ##------------------------------------------------------------------------------------------------
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         -0.2803                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 3000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ3000                         -0.8208                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
+BDTOutput_LQ3000                         -0.2603                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2800                         -0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2900                         -0.3203                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+BDTOutput_LQ2800                         0.02                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ300                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+BDTOutput_LQ300                         0.0801                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2700 optimization
+# LQ M 2900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2700                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+BDTOutput_LQ2900                         0.2002                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2600                         0.3804                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+BDTOutput_LQ2600                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ400                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 500 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ500                         0.6607                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+BDTOutput_LQ400                         0.5806                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2500                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
+BDTOutput_LQ2500                         0.6406                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2300 optimization
+# LQ M 500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2300                         0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2400 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2400                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+BDTOutput_LQ500                         0.6807                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ600                         0.8408                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+BDTOutput_LQ600                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2200 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2200                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+BDTOutput_LQ2200                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2000 optimization
+# LQ M 2400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2000                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+BDTOutput_LQ2400                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 700 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2100 optimization
+# LQ M 2300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2100                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+BDTOutput_LQ2300                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1800 optimization
+# LQ M 800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+BDTOutput_LQ800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1700 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 2000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2000                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 1900 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1900                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 800 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 1000 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 900 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1200 optimization
+# LQ M 1000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1100 optimization
 #------------------------------------------------------------------------------------------------------------------
@@ -304,9 +296,17 @@ BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 1200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 1600 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1600                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1500 optimization
 #------------------------------------------------------------------------------------------------------------------

--- a/config2016/Analysis/preVFP/ignoreNegWeights/cutTable_lq_eejj_QCD_singleFR.txt
+++ b/config2016/Analysis/preVFP/ignoreNegWeights/cutTable_lq_eejj_QCD_singleFR.txt
@@ -1,0 +1,313 @@
+#############################     Example of file with list of cuts
+#
+#
+#------------------------ Preliminary cut variables and values (cut level -1) here -----------------------------
+# This first list of variable names and values are used to pass configurable values to the user code associated
+# to a variable name.
+# The user can retrieve the values associated to a variable name via a provided function call
+# [e.g. getPreCutValue1("eleFidRegion") and similarly for value2, value3 and value4 ]
+# The idea is that the user can use these values to define the list of objects (electrons, jets, etc.) used in
+# analysis. No cut is automatically evaluated on these variables and the cut level must be equal to -1.
+# Variable names must be unique.
+#
+#VariableName         value1            value2          value3          value4          level
+#------------         ------------      -------------   ------------    -------------   -----
+produceSkim           1                 -               -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Preselection cuts
+#-----------------------------------------------------------------------------------------------------------------------------
+eleEta_bar            1.4442           -                -               -               -1
+eleEta_end1           1.566            2.0              -               -               -1
+eleEta_end2           2.000            2.5              -               -               -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Fake rates
+#-----------------------------------------------------------------------------------------------------------------------------
+QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016preVFP/fr2DpreVFP.root - - - -1
+QCDCalcType            single   -   -   -   -1
+PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016 - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# BDT
+#-----------------------------------------------------------------------------------------------------------------------------
+BDTWeightFileLQM300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1100   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1200   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM1900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2100   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2200   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2300   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2400   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2500   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2600   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2700   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2800   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM2900   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+
+BDTWeightFileLQM3000   ${LQINPUTS}/BDT/negWeightStudies/2016preVFP/ignoreNegWeights/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# Analysis year
+#-----------------------------------------------------------------------------------------------------------------------------
+AnalysisYear   2016preVFP  - - - -1
+#------------------------------------------------------------------------------------------------------
+# Electron ID
+#------------------------------------------------------------------------------------------------------
+electronIDType             HEEP  - - - -1
+#-----------------------------------------------------------------------------------------------------------------------------
+# B-tagging
+# See: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation
+#-----------------------------------------------------------------------------------------------------------------------------
+BTagAlgo       DeepJet  - - - -1
+#BTagWP         Loose    - - - -1
+#BTagCutValue   0.0508   - - - -1
+BTagWP         Medium   - - - -1
+BTagCutValue   0.2598   - - - -1
+#
+#-----------------------------------------------------------------------------------------------------------------------------
+#--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
+# The cut variable names, cut boundaries and histogram binnings are provided here by the user.
+# In the event loop of the analysisClass_template.C, the user have to fill each variable with its value using
+# a provided function call [ e.g. fillVariableWithValue("nEleFinal", number_of_electrons) ]
+# The variable names in the user code has to match the names provided here.
+# Variable names must be unique.
+# The cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )
+# in case only the first range (minValue1, maxValue1) is provided,
+# otherwise the cut will be declared "passed" if
+#    ( minValue1 < VariableName <= maxValue1 )  OR  ( minValue2 < VariableName <= maxValue2 )
+# in case even the second range (minValue2, maxValue2) is provided.
+# The level of the cut (0,1,2 ... n) is provided by the user and can be used in the code to easily determine if
+# groups of same-level cuts have passed or failed.
+#
+#VariableName                   minValue1(<) maxValue1(>=)      minValue2(<)    maxValue2(>=)   level   histoNbinsMinMax      OptionalFlag
+#------------                   ------------ -------------      ------------    -------------   -----   ----------------      ------------
+#-----------------------------------------------------------------------------------------------------------------------------
+#                          _           _   _             
+# _ __  _ __ ___  ___  ___| | ___  ___| |_(_) ___  _ __  
+#| '_ \| '__/ _ \/ __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \ 
+#| |_) | | |  __/\__ \  __/ |  __/ (__| |_| | (_) | | | |
+#| .__/|_|  \___||___/\___|_|\___|\___|\__|_|\___/|_| |_|
+#|_|                    
+#-----------------------------------------------------------------------------------------------------------------------------
+Reweighting                        0              1              -           -           0           2             -0.5           1.5
+PassLHECuts                        0              1              -           -           0           2             -0.5           1.5
+PassJSON                           0              1              -           -           0           2             -0.5           1.5
+PassHLT                            0              1              -           -           0           2             -0.5           1.5
+PassGlobalSuperTightHalo2016Filter 0              1              -           -           0           2             -0.5           1.5
+PassGoodVertices                   0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseFilter                0              1              -           -           0           2             -0.5           1.5
+PassHBHENoiseIsoFilter             0              1              -           -           0           2             -0.5           1.5
+PassBadEESupercrystalFilter        0              1              -           -           0           2             -0.5           1.5
+PassEcalDeadCellTrigPrim           0              1              -           -           0           2             -0.5           1.5
+PassBadPFMuonFilter                0              1              -           -           0           2             -0.5           1.5
+PassEcalBadCalibFilter             0              1              -           -           0           2             -0.5           1.5
+PassNEle                           0              1              -           -           0           11            -0.5           10.5
+PassNMuon                          0              1              -           -           0           16            -0.5           15.5
+nEle_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+nJet_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
+Ele1_Pt_skim                       40             +inf           -           -           0           200           0              2000
+Ele2_Pt_skim                       40             +inf           -           -           0           200           0              2000
+PassIDRequirements                 0              1              -           -           0           2             -0.5           1.5
+nJet                               -inf           +inf           -           -           0           16            -0.5           15.5
+Jet1_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet1_Eta                           -2.4           2.4            -           -           0           100           -5             5
+Jet2_Pt_skim                       35             +inf           -           -           0           200           0              2000
+Jet2_Eta                           -2.4           2.4            -           -           0           100           -5             5
+DR_Ele1Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele1Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet1                        -inf           +inf           -           -           0           100           0              10
+DR_Ele2Jet2                        -inf           +inf           -           -           0           100           0              10
+DR_Jet1Jet2                        -inf           +inf           -           -           0           100           0              10
+PFMET_Type1_Pt                     -inf           +inf           -           -           0           200           0              20
+PFMET_Type1_Phi                    -inf           +inf           -           -           0           200           0              2000
+Ele1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.14
+Ele2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Ele1_Eta                           -inf           +inf           -           -           0           100           -5             5
+Ele2_Eta                           -inf           +inf           -           -           0           100           -5             5
+M_e1j1                             -inf           +inf           -           -           0           200           0              2000
+M_e1j2                             -inf           +inf           -           -           0           200           0              2000
+M_e2j1                             -inf           +inf           -           -           0           200           0              2000
+M_e2j2                             -inf           +inf           -           -           0           200           0              2000
+Jet3_Pt                            -inf           +inf           -           -           0           200           0              2000
+Jet3_Eta                           -inf           +inf           -           -           0           100           -5             5
+Jet1_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet2_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Jet3_Phi                           -inf           +inf           -           -           0           60            -3.1416        3.1416
+Masym                              -inf           +inf           -           -           0           200           0              2000
+MejMin                             -inf           +inf           -           -           0           200           0              2000
+MejMax                             -inf           +inf           -           -           0           200           0              2000
+Meejj                              -inf           +inf           -           -           0           200           0              2000
+Pt_e1e2_skim                       50             +inf           -           -           0           200           0              2000
+sT_eejj_skim                       200            +inf           -           -           0           200           0              2000
+M_e1e2_skim                        40             +inf           -           -           0           200           0              2000
+skim_selection                     -inf           +inf           -           -           0           2             -0.5           1.5
+Ele1_Pt                            50             +inf           -           -           0           200           0              2000
+Ele2_Pt                            50             +inf           -           -           0           200           0              2000
+Jet1_Pt                            50             +inf           -           -           0           200           0              2000
+Jet2_Pt                            50             +inf           -           -           0           200           0              2000
+Pt_e1e2                            70             +inf           -           -           0           200           0              2000
+sT_eejj_bkgCR                      300            +inf           -           -           0           200           0              2000
+M_e1e2_bkgCR                       50             +inf           -           -           0           200           0              2000
+preselection                       -inf           +inf           -           -           0           2             -0.5           1.5
+sT_eejj                            400            +inf           -           -           0           200           0              2000
+M_e1e2                             220            +inf           -           -           0           200           0              2000
+trainingSelection                  -inf           +inf           -           -           1           2             -0.5           1.5
+#-----------------------------------------------------------------------------------------------------------------------------
+#  __ _             _            _           _   _                                                                        
+# / _(_)_ __   __ _| |  ___  ___| | ___  ___| |_(_) ___  _ __                                                             
+#| |_| | '_ \ / _` | | / __|/ _ \ |/ _ \/ __| __| |/ _ \| '_ \                                                            
+#|  _| | | | | (_| | | \__ \  __/ |  __/ (__| |_| | (_) | | | |                                                           
+#|_| |_|_| |_|\__,_|_| |___/\___|_|\___|\___|\__|_|\___/|_| |_|                                                           
+#-----------------------------------------------------------------------------------------------------------------------------
+# CUTS GET PROGRESSIVELY TIGHTER
+##------------------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 3000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ3000                         -0.8208                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2800                         -0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2900                         -0.3203                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ300                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2600                         0.3804                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ400                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ500                         0.6607                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2500                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2300                         0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2400                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ600                         0.8408                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2200                         0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2000                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2100                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1000 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1200 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1200,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1100 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1100                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1300 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1400 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1600 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1600                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1500                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection

--- a/config2016/Analysis/preVFP/powheg-amcatnlo/cutTable_lq_eejj_BDT.txt
+++ b/config2016/Analysis/preVFP/powheg-amcatnlo/cutTable_lq_eejj_BDT.txt
@@ -20,88 +20,104 @@ eleEta_bar            1.4442           -                -               -       
 eleEta_end1           1.566            2.0              -               -               -1
 eleEta_end2           2.000            2.5              -               -               -1
 #-----------------------------------------------------------------------------------------------------------------------------
-# Fake rates
-#-----------------------------------------------------------------------------------------------------------------------------
-QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016postVFP/fr2DpostVFP.root - - - -1
-QCDCalcType            single   -   -   -   -1
-PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016 - - - -1
-#-----------------------------------------------------------------------------------------------------------------------------
 # BDT
 #-----------------------------------------------------------------------------------------------------------------------------
-BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # Analysis year
 #-----------------------------------------------------------------------------------------------------------------------------
-AnalysisYear   2016postVFP  - - - -1
-#------------------------------------------------------------------------------------------------------
-# Electron ID
-#------------------------------------------------------------------------------------------------------
-electronIDType             HEEP  - - - -1
+AnalysisYear   2016  - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # B-tagging
 # See: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation
 #-----------------------------------------------------------------------------------------------------------------------------
 BTagAlgo       DeepJet  - - - -1
 #BTagWP         Loose    - - - -1
-#BTagCutValue   0.0480   - - - -1
+#BTagCutValue   0.0508   - - - -1
 BTagWP         Medium   - - - -1
-BTagCutValue   0.2489   - - - -1
+BTagCutValue   0.2598   - - - -1
 #
 #-----------------------------------------------------------------------------------------------------------------------------
+# systematics
+#-----------------------------------------------------------------------------------------------------------------------------
+#         name              source/formula/branch                                       cutVars
+#         ------------      ------------------------------------------------------      --------------------------------------
+#SYST      FivePercentUp     1.05
+SYST      PrefireDown       PrefireWeight_Dn/PrefireWeight
+SYST      PrefireUp         PrefireWeight_Up/PrefireWeight
+SYST      JERDown           regex=".+jerdown.*"                                         sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JERUp             regex=".+jerup.*"                                           sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JESDown           regex=".+jesTotaldown.*"                                    sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+SYST      JESUp             regex=".+jesTotalup.*"                                      sT_eejj,Jet2_Pt,Jet1_Pt,Jet3_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,PFMET_Type1_Pt,PFMET_Type1_Phi,Masym,MejMin,MejMax,Meejj
+#FIXME: EER/EES effect on MET?
+SYST      EERDown           regex=".+EER_Dn.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EERUp             regex=".+EER_Up.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EESDown           regex=".+EES_Dn.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EESUp             regex=".+EES_Up.*"                                           sT_eejj,M_e1e2,Ele1_Pt,Ele2_Pt,M_e1j1,M_e1j2,M_e2j1,M_e2j2,Pt_e1e2,Masym,MejMin,MejMax,Meejj
+SYST      EleRecoSFUp       (Ele1_RecoSF_Up/Ele1_RecoSF)*(Ele2_RecoSF_Up/Ele2_RecoSF)
+SYST      EleRecoSFDown     (Ele1_RecoSF_Dn/Ele1_RecoSF)*(Ele2_RecoSF_Dn/Ele2_RecoSF)
+SYST      EleIDSFUp         ((Ele1_HEEPSF+Ele1_HEEPSF_Err)/Ele1_HEEPSF)*((Ele2_HEEPSF+Ele2_HEEPSF_Err)/Ele2_HEEPSF)
+SYST      EleIDSFDown       ((Ele1_HEEPSF-Ele1_HEEPSF_Err)/Ele1_HEEPSF)*((Ele2_HEEPSF-Ele2_HEEPSF_Err)/Ele2_HEEPSF)
+SYST      EleTrigSFUp       
+SYST      EleTrigSFDown     
+SYST      PileupUp          puWeight_Up/puWeight
+SYST      PileupDown        puWeight_Dn/puWeight
+SYST      LHEPdfWeight      LHEPdfWeight
+SYST      LHEScaleWeight    LHEScaleWeight
 #--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
 # The cut variable names, cut boundaries and histogram binnings are provided here by the user.
 # In the event loop of the analysisClass_template.C, the user have to fill each variable with its value using
@@ -145,7 +161,6 @@ nEle_hltMatched                    -inf           +inf           -           -  
 nJet_hltMatched                    -inf           +inf           -           -           0           3             -0.5           2.5
 Ele1_Pt_skim                       40             +inf           -           -           0           200           0              2000
 Ele2_Pt_skim                       40             +inf           -           -           0           200           0              2000
-PassIDRequirements                 0              1              -           -           0           2             -0.5           1.5
 nJet                               -inf           +inf           -           -           0           16            -0.5           15.5
 Jet1_Pt_skim                       35             +inf           -           -           0           200           0              2000
 Jet1_Eta                           -2.4           2.4            -           -           0           100           -5             5
@@ -186,9 +201,9 @@ Jet2_Pt                            50             +inf           -           -  
 Pt_e1e2                            70             +inf           -           -           0           200           0              2000
 sT_eejj_bkgCR                      300            +inf           -           -           0           200           0              2000
 M_e1e2_bkgCR                       50             +inf           -           -           0           200           0              2000
-preselection                       -inf           +inf           -           -           0           2             -0.5           1.5
-sT_eejj                            400            +inf           -           -           0           200           0              2000
-M_e1e2                             220            +inf           -           -           0           200           0              2000
+preselection                       -inf           +inf           -           -           0           2             -0.5           1.5     SYSTS
+sT_eejj                            400            +inf           -           -           0           200           0              2000    SYSTS
+M_e1e2                             220            +inf           -           -           0           200           0              2000    SYSTS
 trainingSelection                  -inf           +inf           -           -           1           2             -0.5           1.5
 #-----------------------------------------------------------------------------------------------------------------------------
 #  __ _             _            _           _   _                                                                        
@@ -200,97 +215,85 @@ trainingSelection                  -inf           +inf           -           -  
 # CUTS GET PROGRESSIVELY TIGHTER
 ##------------------------------------------------------------------------------------------------
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         0.02                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 3000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ3000                         -0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2900                         -0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+BDTOutput_LQ3000                         0.02                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2800                         -0.6807                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2600 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2600                         -0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2700 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2700                         -0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2500 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2500                         -0.1602                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2300 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2300                         0.3003                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+BDTOutput_LQ2800                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ300                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+BDTOutput_LQ300                         0.2202                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2400 optimization
+# LQ M 2900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2400                         0.3604                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2200 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2200                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+BDTOutput_LQ2900                         0.2803                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ400                         0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+BDTOutput_LQ400                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2100 optimization
+# LQ M 2600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2100                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+BDTOutput_LQ2600                         0.6607                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2500                         0.7407                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ500                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+BDTOutput_LQ500                         0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2000 optimization
+# LQ M 2300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2000                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 1900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1900                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+BDTOutput_LQ2300                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 600 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ600                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 800 optimization
+# LQ M 2400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+BDTOutput_LQ2400                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 700 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1800 optimization
+# LQ M 2200 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+BDTOutput_LQ2200                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1600 optimization
+# LQ M 2000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1600                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+BDTOutput_LQ2000                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1700 optimization
+# LQ M 2100 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+BDTOutput_LQ2100                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1000 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 900 optimization
+# LQ M 1300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1100 optimization
 #------------------------------------------------------------------------------------------------------------------
@@ -304,10 +307,22 @@ BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1300 optimization
+# LQ M 1600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+BDTOutput_LQ1600                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1500 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1500                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection

--- a/config2016/Analysis/preVFP/powheg-amcatnlo/cutTable_lq_eejj_QCD_doubleFR.txt
+++ b/config2016/Analysis/preVFP/powheg-amcatnlo/cutTable_lq_eejj_QCD_doubleFR.txt
@@ -22,71 +22,71 @@ eleEta_end2           2.000            2.5              -               -       
 #-----------------------------------------------------------------------------------------------------------------------------
 # Fake rates
 #-----------------------------------------------------------------------------------------------------------------------------
-QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016postVFP/fr2DpostVFP.root - - - -1
-QCDCalcType            single   -   -   -   -1
+QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016preVFP/fr2DpreVFP.root - - - -1
+QCDCalcType            double   -   -   -   -1
 PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016 - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # BDT
 #-----------------------------------------------------------------------------------------------------------------------------
-BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # Analysis year
 #-----------------------------------------------------------------------------------------------------------------------------
-AnalysisYear   2016postVFP  - - - -1
+AnalysisYear   2016preVFP  - - - -1
 #------------------------------------------------------------------------------------------------------
 # Electron ID
 #------------------------------------------------------------------------------------------------------
@@ -97,9 +97,9 @@ electronIDType             HEEP  - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 BTagAlgo       DeepJet  - - - -1
 #BTagWP         Loose    - - - -1
-#BTagCutValue   0.0480   - - - -1
+#BTagCutValue   0.0508   - - - -1
 BTagWP         Medium   - - - -1
-BTagCutValue   0.2489   - - - -1
+BTagCutValue   0.2598   - - - -1
 #
 #-----------------------------------------------------------------------------------------------------------------------------
 #--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
@@ -200,97 +200,85 @@ trainingSelection                  -inf           +inf           -           -  
 # CUTS GET PROGRESSIVELY TIGHTER
 ##------------------------------------------------------------------------------------------------
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         0.02                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 3000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ3000                         -0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2900                         -0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+BDTOutput_LQ3000                         0.02                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2800                         -0.6807                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2600 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2600                         -0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2700 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2700                         -0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2500 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2500                         -0.1602                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2300 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2300                         0.3003                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+BDTOutput_LQ2800                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ300                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+BDTOutput_LQ300                         0.2202                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2400 optimization
+# LQ M 2900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2400                         0.3604                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2200 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2200                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+BDTOutput_LQ2900                         0.2803                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ400                         0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+BDTOutput_LQ400                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2100 optimization
+# LQ M 2600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2100                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+BDTOutput_LQ2600                         0.6607                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2500                         0.7407                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ500                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+BDTOutput_LQ500                         0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2000 optimization
+# LQ M 2300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2000                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 1900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1900                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+BDTOutput_LQ2300                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 600 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ600                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 800 optimization
+# LQ M 2400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+BDTOutput_LQ2400                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 700 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1800 optimization
+# LQ M 2200 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+BDTOutput_LQ2200                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1600 optimization
+# LQ M 2000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1600                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+BDTOutput_LQ2000                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1700 optimization
+# LQ M 2100 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+BDTOutput_LQ2100                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1000 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 900 optimization
+# LQ M 1300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1100 optimization
 #------------------------------------------------------------------------------------------------------------------
@@ -304,10 +292,22 @@ BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1300 optimization
+# LQ M 1600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+BDTOutput_LQ1600                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1500 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1500                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection

--- a/config2016/Analysis/preVFP/powheg-amcatnlo/cutTable_lq_eejj_QCD_singleFR.txt
+++ b/config2016/Analysis/preVFP/powheg-amcatnlo/cutTable_lq_eejj_QCD_singleFR.txt
@@ -22,71 +22,71 @@ eleEta_end2           2.000            2.5              -               -       
 #-----------------------------------------------------------------------------------------------------------------------------
 # Fake rates
 #-----------------------------------------------------------------------------------------------------------------------------
-QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016postVFP/fr2DpostVFP.root - - - -1
+QCDFakeRateFilename	   ${LQINPUTS}/fakeRate/2016preVFP/fr2DpreVFP.root - - - -1
 QCDCalcType            single   -   -   -   -1
 PrescaleProviderInfo       ${LQINPUTS}/prescales/2016/triggerData2016 - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # BDT
 #-----------------------------------------------------------------------------------------------------------------------------
-BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM1900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-1900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2100   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2100_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2200   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2200_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2300   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2300_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2400   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2400_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2500   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2500_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2600   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2600_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2700   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2700_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2800   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2800_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM2900   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-2900_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 
-BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016postVFP/HTLO-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_BDTG.weights.xml - - - -1
+BDTWeightFileLQM3000   /eos/user/e/eipearso/LQ_BDTWeightFiles/2016preVFP/powheg-amcatnlo_17apr24/weights/TMVAClassification_LQToDEle_M-3000_pair_bMassZero_TuneCP2_13TeV-madgraph-pythia8_APV_BDTG.weights.xml - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 # Analysis year
 #-----------------------------------------------------------------------------------------------------------------------------
-AnalysisYear   2016postVFP  - - - -1
+AnalysisYear   2016preVFP  - - - -1
 #------------------------------------------------------------------------------------------------------
 # Electron ID
 #------------------------------------------------------------------------------------------------------
@@ -97,9 +97,9 @@ electronIDType             HEEP  - - - -1
 #-----------------------------------------------------------------------------------------------------------------------------
 BTagAlgo       DeepJet  - - - -1
 #BTagWP         Loose    - - - -1
-#BTagCutValue   0.0480   - - - -1
+#BTagCutValue   0.0508   - - - -1
 BTagWP         Medium   - - - -1
-BTagCutValue   0.2489   - - - -1
+BTagCutValue   0.2598   - - - -1
 #
 #-----------------------------------------------------------------------------------------------------------------------------
 #--------------------------------- Cuts (level 0,1,2,3 ... n) below --------------------------------------------
@@ -200,97 +200,85 @@ trainingSelection                  -inf           +inf           -           -  
 # CUTS GET PROGRESSIVELY TIGHTER
 ##------------------------------------------------------------------------------------------------
 #------------------------------------------------------------------------------------------------------------------
+# LQ M 2700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2700                         0.02                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
 # LQ M 3000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ3000                         -0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2900                         -0.8809                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
+BDTOutput_LQ3000                         0.02                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM3000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 2800 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2800                         -0.6807                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2600 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2600                         -0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2700 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2700                         -0.5205                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2700,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2500 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2500                         -0.1602                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2300 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2300                         0.3003                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
+BDTOutput_LQ2800                         0.1201                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ300                         0.3403                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
+BDTOutput_LQ300                         0.2202                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2400 optimization
+# LQ M 2900 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2400                         0.3604                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 2200 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2200                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
+BDTOutput_LQ2900                         0.2803                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2900,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ400                         0.6206                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
+BDTOutput_LQ400                         0.4805                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2100 optimization
+# LQ M 2600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2100                         0.7007                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+BDTOutput_LQ2600                         0.6607                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2600,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 2500 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ2500                         0.7407                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 500 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ500                         0.7608                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
+BDTOutput_LQ500                         0.7808                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM500,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 2000 optimization
+# LQ M 2300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ2000                         0.8008                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
-#------------------------------------------------------------------------------------------------------------------
-# LQ M 1900 optimization
-#------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1900                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection
+BDTOutput_LQ2300                         0.9009                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 600 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ600                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 800 optimization
+# LQ M 2400 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
+BDTOutput_LQ2400                         0.9209                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 700 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ700                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM700,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1800 optimization
+# LQ M 2200 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1800                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+BDTOutput_LQ2200                         0.9409                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2200,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1600 optimization
+# LQ M 2000 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1600                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
+BDTOutput_LQ2000                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1700 optimization
+# LQ M 2100 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1700                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+BDTOutput_LQ2100                         0.961                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM2100,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM800,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1000 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1000                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1000,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 900 optimization
+# LQ M 1300 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM900,trainingSelection
+BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1100 optimization
 #------------------------------------------------------------------------------------------------------------------
@@ -304,10 +292,22 @@ BDTOutput_LQ1200                         0.981                +inf 		-		-	2	100 
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1400                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1400,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
-# LQ M 1300 optimization
+# LQ M 1600 optimization
 #------------------------------------------------------------------------------------------------------------------
-BDTOutput_LQ1300                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1300,trainingSelection
+BDTOutput_LQ1600                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1600,trainingSelection
 #------------------------------------------------------------------------------------------------------------------
 # LQ M 1500 optimization
 #------------------------------------------------------------------------------------------------------------------
 BDTOutput_LQ1500                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1500,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1700 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1700                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1700,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1800 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1800                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1800,trainingSelection
+#------------------------------------------------------------------------------------------------------------------
+# LQ M 1900 optimization
+#------------------------------------------------------------------------------------------------------------------
+BDTOutput_LQ1900                         0.981                +inf 		-		-	2	100 -1 1    TMVACut:BDT,BDTWeightFileLQM1900,trainingSelection


### PR DESCRIPTION
adds cutfiles needed to run the analysis with the new BDTs that have been trained on pohwegMiNNLO DY / HT LO DY. Also adds updated cutfiles for training with amcatnlo DY that ignores negative weights and does not include QCD in training (but does in testing/optimization)